### PR TITLE
Add check if query is empty

### DIFF
--- a/privateGPT.py
+++ b/privateGPT.py
@@ -20,7 +20,9 @@ def main():
         query = input("\nEnter a query: ")
         if query == "exit":
             break
-        
+        if query.strip() == "":
+            print("error: query empty!")
+            continue
         # Get the answer from the chain
         res = qa(query)    
         answer, docs = res['result'], res['source_documents']


### PR DESCRIPTION
When giving an empty query it can be annoying waiting for the response. We should check this and continue if query is empty. 