### PR TITLE
Fix persist db directory at ingestion

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,7 +1,11 @@
+import os
+from dotenv import load_dotenv
 from chromadb.config import Settings
 
+load_dotenv()
+
 # Define the folder for storing database
-PERSIST_DIRECTORY = 'db'
+PERSIST_DIRECTORY = os.environ.get('PERSIST_DIRECTORY')
 
 # Define the Chroma settings
 CHROMA_SETTINGS = Settings(

--- a/ingest.py
+++ b/ingest.py
@@ -4,7 +4,6 @@ from langchain.document_loaders import TextLoader, PDFMinerLoader, CSVLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.vectorstores import Chroma
 from langchain.embeddings import LlamaCppEmbeddings
-from constants import PERSIST_DIRECTORY
 from constants import CHROMA_SETTINGS
 
 load_dotenv()
@@ -28,7 +27,7 @@ def main():
     # Create embeddings
     llama = LlamaCppEmbeddings(model_path=llama_embeddings_model, n_ctx=model_n_ctx)
     # Create and store locally vectorstore
-    db = Chroma.from_documents(texts, llama, persist_directory=PERSIST_DIRECTORY, client_settings=CHROMA_SETTINGS)
+    db = Chroma.from_documents(texts, llama, persist_directory=persist_directory, client_settings=CHROMA_SETTINGS)
     db.persist()
     db = None
 


### PR DESCRIPTION
- Ingestion uses the persist directory hard-coded in the `constants.py` file; itself is not synced with `.env`.
- Fixed to make it consistent across the project and use the users' defined variable.