### PR TITLE
Made changes in constants.py so that it can automatically create the db directory and set the PERSIST_DIRECTORY enviroment variable if people  forget to do it.

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -6,6 +6,11 @@ load_dotenv()
 
 # Define the folder for storing database
 PERSIST_DIRECTORY = os.environ.get('PERSIST_DIRECTORY')
+if PERSIST_DIRECTORY is None:
+    path_to_dir = os.path.join("privateGPT", "db")
+    print(f"Creating a directory for storing database... [path:{path_to_dir}]")
+    os.mkdir(path_to_dir)
+    os.environ["PERSIST_DIRECTORY"] = path_to_dir
 
 # Define the Chroma settings
 CHROMA_SETTINGS = Settings(


### PR DESCRIPTION
Made changes so that "db" to store databases (_labelled under environ name **PERSIST_DIRECTORY_**) directory can be automatically created and be assigned as their environment variable as most people forget to do this quite often and the error they receive is very confusing to follow and doesn't explain the situation at all.