### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ unstructured==0.6.6
 extract-msg==0.41.1
 tabulate==0.9.0
 pandoc==2.3
-pypandoc-binary==1.11
+pypandoc==1.11


### PR DESCRIPTION
I attempted to resolve this issue for the Mac M1, but it only works if you first install Brew, followed by Pandoc using the command 'brew install pandoc', and then install pypandoc version 1.11.