### PR TITLE
remove duplicate call 'load_dotenv()' in ingester.py

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -24,9 +24,6 @@ from langchain.docstore.document import Document
 from constants import CHROMA_SETTINGS
 
 
-load_dotenv()
-
-
 # Map file extensions to document loaders and their arguments
 LOADER_MAPPING = {
     ".csv": (CSVLoader, {}),


### PR DESCRIPTION

Nothing too serious. 'load_dotenv()' in called twice in ingester.py

One line was removed.