### PR TITLE
Make scripts executable, add basic pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+---
+files: ^(.*\.(py|json|md|sh|yaml|cfg|txt))$
+exclude: ^(\.[^/]*cache/.*|.*/_user.py|source_documents/)$
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      #- id: no-commit-to-branch
+      #  args: [--branch, main]
+      - id: check-yaml
+        args: [--unsafe]
+      # - id: debug-statements
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        exclude-files: \.md$
+      - id: check-json
+      - id: mixed-line-ending
+      # - id: check-builtin-literals
+      # - id: check-ast
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-docstring-first
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      # - id: check-toml
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.29.0
+    hooks:
+      - id: yamllint
+        args:
+          - --no-warnings
+          - -d
+          - '{extends: relaxed, rules: {line-length: {max: 90}}}'
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+        args:
+          # - --builtin=clear,rare,informal,usage,code,names,en-GB_to_en-US
+          - --builtin=clear,rare,informal,usage,code,names
+          - --ignore-words-list=hass,master
+          - --skip="./.*"
+          - --quiet-level=2

--- a/ingest.py
+++ b/ingest.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import glob
 from typing import List
@@ -107,7 +108,7 @@ def main():
 
     # Create embeddings
     embeddings = HuggingFaceEmbeddings(model_name=embeddings_model_name)
-    
+
     # Create and store locally vectorstore
     db = Chroma.from_documents(texts, embeddings, persist_directory=persist_directory, client_settings=CHROMA_SETTINGS)
     db.persist()

--- a/privateGPT.py
+++ b/privateGPT.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from dotenv import load_dotenv
 from langchain.chains import RetrievalQA
 from langchain.embeddings import HuggingFaceEmbeddings
@@ -37,9 +38,9 @@ def main():
         query = input("\nEnter a query: ")
         if query == "exit":
             break
-        
+
         # Get the answer from the chain
-        res = qa(query)    
+        res = qa(query)
         answer, docs = res['result'], res['source_documents']
 
         # Print the result
@@ -47,7 +48,7 @@ def main():
         print(query)
         print("\n> Answer:")
         print(answer)
-        
+
         # Print the relevant sources used for the answer
         for document in docs:
             print("\n> " + document.metadata["source"] + ":")


### PR DESCRIPTION
Changes to execute ingest.py and privateGPT.py without needing to manually add python3 for executing them.

Also added a "minimal" pre-commit configuration that will not make major changes to the files - for now it removed some spaces at the end of the lines.  It also checks spelling, yaml format (useful for the docker configuration that is prepared in another PR).