### PR TITLE
Update ingest.py: Fix duplication of load_dotenv() and uncomment Docx2txtLoader

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 
 from langchain.document_loaders import (
     CSVLoader,
+    Docx2txtLoader,
     EverNoteLoader,
     PDFMinerLoader,
     TextLoader,

--- a/ingest.py
+++ b/ingest.py
@@ -30,7 +30,7 @@ load_dotenv()
 # Map file extensions to document loaders and their arguments
 LOADER_MAPPING = {
     ".csv": (CSVLoader, {}),
-    # ".docx": (Docx2txtLoader, {}),
+    ".docx": (Docx2txtLoader, {}),
     ".docx": (UnstructuredWordDocumentLoader, {}),
     ".enex": (EverNoteLoader, {}),
     ".eml": (UnstructuredEmailLoader, {}),
@@ -43,9 +43,6 @@ LOADER_MAPPING = {
     ".txt": (TextLoader, {"encoding": "utf8"}),
     # Add more mappings for other file extensions and loaders as needed
 }
-
-
-load_dotenv()
 
 
 def load_single_document(file_path: str) -> Document:


### PR DESCRIPTION
This pull request addresses two specific changes:

1. Removal of `load_dotenv()` duplication: Previously, the `load_dotenv()` function was called twice in the code, leading to unnecessary duplication. In this pull request, I have removed the duplicated call and added it once at the beginning of the script to ensure proper loading of environment variables.

2. Uncommenting `# ".docx": (Docx2txtLoader, {})` line.
