### PR TITLE
Optimize load_documents function with multiprocessing

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -2,6 +2,7 @@ import os
 import glob
 from typing import List
 from dotenv import load_dotenv
+from multiprocessing import Pool
 
 from langchain.document_loaders import (
     CSVLoader,
@@ -64,7 +65,9 @@ def load_documents(source_dir: str) -> List[Document]:
         all_files.extend(
             glob.glob(os.path.join(source_dir, f"**/*{ext}"), recursive=True)
         )
-    return [load_single_document(file_path) for file_path in all_files]
+    with Pool(processes=os.cpu_count()) as pool:
+        documents = pool.map(load_single_document, all_files)
+    return documents
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ extract-msg==0.41.1
 tabulate==0.9.0
 pandoc==2.3
 pypandoc==1.11
+tqdm==4.65.0


### PR DESCRIPTION
This pull request introduces multiprocessing in the `load_documents()` function to improve performance by utilizing multiple cores for document loading.

**Key Changes**

- The `load_documents()` function now uses Python's multiprocessing module, allowing for concurrent document loading across multiple CPU cores.
- This modification takes advantage of machines with multiple cores and/or hyper-threading capabilities, leading to significant potential improvements in document loading times.
- It enhances performance, especially when dealing with a large number of documents.

This update is expected to significantly speed up the document loading process, contributing to overall system efficiency and user experience. Please review and provide your feedback.


***^^^This commit message is generated by ChatGPT^^^***