### PR TITLE
added CASALIOY ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,10 @@ When running a Mac with Intel hardware (not M1), you may run into _clang: error:
 
 If so set your archflags during pip install. eg: _ARCHFLAGS="-arch x86_64" pip3 install -r requirements.txt_
 
+## Other Alternatives (run locally)
+
+- [Casalioy](https://github.com/su77ungr/CASALIOY) toolkit with GUI (also fixed several issues of this repo)
+
+
 # Disclaimer
 This is a test project to validate the feasibility of a fully private solution for question answering using LLMs and Vector embeddings. It is not production ready, and it is not meant to be used in production. The models selection is not optimized for performance, but for privacy; but it is possible to use different models and vectorstores to improve performance.


### PR DESCRIPTION
**Add note inside README** 

references [CASALIOY (air-gapped toolkit)](https://github.com/su77ungr/CASALIOY) 

**Why _your_ community would benefit?**
We took some time and effort to supercharge this base idea of a private LLM client and solved dozens of your repo's **issues** also. Choosing different routes in things like vector storage, ingestion approach and GUI for good measure. Some but not all features:

- [x] Speed improvements through _qdrant_ and change in the base model
- [x] Blazing fast _parallelized ingestion_ and local HF tokenizer
- [x] _GUI_ built with streamlit to let your family chat in the browser (easy to embed) 

## full text in ISSUE #303 

