### PR TITLE
Added script arguments to disable printing of LLM stdout Stream and source documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,25 +83,7 @@ Type `exit` to finish the script.
 
 
 ### Script Arguments
-The script also supports optional command-line arguments to modify its behavior:
-
-- `--hide-source` or `-S`: Use this flag to disable printing of the source documents used for answers. By default, the source documents are printed.
-  
-```shell
-python privateGPT.py --hide-source
-```
-
-- `--mute-stream` or `-M`: Use this flag to disable LLM standard output streaming response, which by default prints progress to the console.
-
-```shell
-python privateGPT.py --mute-stream
-```
-
-You can combine these options if needed:
-
-```shell
-python privateGPT.py --hide-source --mute-callback
-```
+The script also supports optional command-line arguments to modify its behavior. You can see a full list of these arguments by running the command ```python privateGPT.py --help``` in your terminal
 
 
 # How does it work?

--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ Note: you could turn off your internet connection, and the script inference woul
 
 Type `exit` to finish the script.
 
+
+### Script Arguments
+The script also supports optional command-line arguments to modify its behavior:
+
+- `--hide-source` or `-S`: Use this flag to disable printing of the source documents used for answers. By default, the source documents are printed.
+  
+```shell
+python privateGPT.py --hide-source
+```
+
+- `--mute-stream` or `-M`: Use this flag to disable LLM standard output streaming response, which by default prints progress to the console.
+
+```shell
+python privateGPT.py --mute-stream
+```
+
+You can combine these options if needed:
+
+```shell
+python privateGPT.py --hide-source --mute-callback
+```
+
+
 # How does it work?
 Selecting the right local models and the power of `LangChain` you can run the entire pipeline locally, without any data leaving your environment, and with reasonable performance.
 


### PR DESCRIPTION
Sometimes may not need the source or the LLM stdout stream to be shown, just need the answer.

Refactored main function to take hide_source and mute_stream parameters for controlling output. 
Added argparse for command-line argument parsing. 
StreamingStdOutCallbackHandler and source document display are now optional based on user input.  

kept the current behaviour as the default when not parsing any arguments. 

Also, updated README.md to reflect these changes.