### PR TITLE
Fix future incompatibility from langchain Chroma

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -79,7 +79,9 @@ def main():
     chunk_overlap = 50
     documents = load_documents(source_directory)
     text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
-    texts = text_splitter.split_documents(documents)
+    text_docs = text_splitter.split_documents(documents)
+    texts = [doc.page_content for doc in text_docs]
+    metadatas = [doc.metadata for doc in text_docs]
     print(f"Loaded {len(documents)} documents from {source_directory}")
     print(f"Split into {len(texts)} chunks of text (max. {chunk_size} characters each)")
 
@@ -87,7 +89,7 @@ def main():
     embeddings = HuggingFaceEmbeddings(model_name=embeddings_model_name)
     
     # Create and store locally vectorstore
-    db = Chroma.from_documents(texts, embeddings, persist_directory=persist_directory, client_settings=CHROMA_SETTINGS)
+    db = Chroma.from_texts(texts=texts, embedding=embeddings, metadatas=metadatas, persist_directory=persist_directory, client_settings=CHROMA_SETTINGS)
     db.persist()
     db = None
 

--- a/ingest.py
+++ b/ingest.py
@@ -79,9 +79,9 @@ def main():
     chunk_overlap = 50
     documents = load_documents(source_directory)
     text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
-    text_docs = text_splitter.split_documents(documents)
-    texts = [doc.page_content for doc in text_docs]
-    metadatas = [doc.metadata for doc in text_docs]
+    chunks = text_splitter.split_documents(documents)
+    texts = [doc.page_content for doc in chunks]
+    metadatas = [doc.metadata for doc in chunks]
     print(f"Loaded {len(documents)} documents from {source_directory}")
     print(f"Split into {len(texts)} chunks of text (max. {chunk_size} characters each)")
 

--- a/ingest.py
+++ b/ingest.py
@@ -89,7 +89,7 @@ def main():
     embeddings = HuggingFaceEmbeddings(model_name=embeddings_model_name)
     
     # Create and store locally vectorstore
-    db = Chroma.from_texts(texts=texts, embedding=embeddings, metadatas=metadatas, persist_directory=persist_directory, client_settings=CHROMA_SETTINGS)
+    db = Chroma.from_texts(texts, embeddings, metadatas=metadatas, persist_directory=persist_directory, client_settings=CHROMA_SETTINGS)
     db.persist()
     db = None
 


### PR DESCRIPTION
Cleanup #5003 which removes the from_documents functionality which conflicted with another method of the same name.
Replaced from_documents with from_texts. See:
https://github.com/hwchase17/langchain/pull/5003

It looks like this will go through and they have marked the change as breaking existing code when it goes into the main branch and is released.

In more detail, the from_documents method is removed and another incompatible prototype is all that remains (in vectorstores.py)
Apparently, the from_documents implementation used in privateGPT was a convenience to connect the output of text_splitters (Documents) which contain both the text and metadata to Chroma from_texts which expects two lists, one with strings and one with dicts (metadata). The code used in the old implementation of from_documents to split the Document list into two list is inserted into ingest.py (main) to allow use of the from_texts method.
This approach is compatible with both the old and prospective versions of langchains support for the Chroma db.

This is my first pull request, so feel free to correct my technique.