### PR TITLE
Ensure file extension is in lowercase text before loader lookup.

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -82,7 +82,7 @@ LOADER_MAPPING = {
 
 
 def load_single_document(file_path: str) -> Document:
-    ext = "." + file_path.rsplit(".", 1)[-1]
+    ext = ("." + file_path.rsplit(".", 1)[-1]).lower()
     if ext in LOADER_MAPPING:
         loader_class, loader_args = LOADER_MAPPING[ext]
         loader = loader_class(file_path, **loader_args)


### PR DESCRIPTION
Previously documents like `ABC.PDF` would be rejected as an invalid file format, this allows any capitalisation combination for file extensions.