### PR TITLE
typo: Change `pip` to `pip3` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built with [LangChain](https://github.com/hwchase17/langchain), [GPT4All](https:
 In order to set your environment up to run the code here, first install all requirements:
 
 ```shell
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 ```
 
 Then, download the LLM model and place it in a directory of your choice:


### PR DESCRIPTION
On some environments with both Python 2.x and 3.x installed, `pip` will be used for 2.x.