### PR TITLE
Improve Handling of Unsupported File Extensions

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -88,7 +88,8 @@ def load_single_document(file_path: str) -> Document:
         loader = loader_class(file_path, **loader_args)
         return loader.load()[0]
 
-    raise ValueError(f"Unsupported file extension '{ext}'")
+    print(f"Warning: Unsupported file extension '{ext}' for file {file_path}. Skipping this file.")
+    return None
 
 
 def load_documents(source_dir: str, ignored_files: List[str] = []) -> List[Document]:
@@ -106,7 +107,8 @@ def load_documents(source_dir: str, ignored_files: List[str] = []) -> List[Docum
         results = []
         with tqdm(total=len(filtered_files), desc='Loading new documents', ncols=80) as pbar:
             for i, doc in enumerate(pool.imap_unordered(load_single_document, filtered_files)):
-                results.append(doc)
+                if doc is not None:
+                    results.append(doc)
                 pbar.update()
 
     return results


### PR DESCRIPTION
Improves the handling of files with unsupported extensions during the document ingestion process. 

Previously, if a file with an unsupported extension was encountered, the `load_single_document` function would raise a `ValueError`, potentially interrupting the ingestion process.

With this change, the `load_single_document` function will simply print a warning message and return `None` when it encounters a file with an unsupported extension. The `load_documents` function has also been updated to filter out these `None` results. This means that the ingestion process will continue with the rest of the files even if some files have unsupported extensions.