### PR TITLE
Added support for CLI args for ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Type `exit` to finish the script.
 
 
 ### CLI
-The script also supports optional command-line arguments to modify its behavior. You can see a full list of these arguments by running the command ```python privateGPT.py --help``` in your terminal.
+The script also supports optional command-line arguments to modify its behavior. You can see a full list of these arguments by running the command ```python privateGPT.py --help``` or ```python ingest.py --help``` in your terminal.
 
 
 # How does it work?

--- a/argsHandler.py
+++ b/argsHandler.py
@@ -1,0 +1,51 @@
+import argparse
+
+
+class ArgsHandler:
+    PRIVATE_GPT = 'privategpt'
+    INGEST = 'ingest'
+
+    @staticmethod
+    def parse_args(description, arguments):
+        parser = argparse.ArgumentParser(description=description)
+        for arg in arguments:
+            parser.add_argument(*arg['args'], **arg['kwargs'])
+        return parser.parse_args()
+
+    @staticmethod
+    def get_args(type):
+        if type == ArgsHandler.PRIVATE_GPT:
+            description = 'privateGPT: Ask questions to your documents without an internet connection, using the ' \
+                          'power of LLMs.'
+            arguments = [
+                {
+                    'args': ["--hide-source", "-S"],
+                    'kwargs': {'action': 'store_true',
+                               'help': 'Use this flag to disable printing of source documents used for answers.'}
+                },
+                {
+                    'args': ["--mute-stream", "-M"],
+                    'kwargs': {'action': 'store_true',
+                               'help': 'Use this flag to disable the streaming StdOut callback for LLMs.'}
+                },
+            ]
+        elif type == ArgsHandler.INGEST:
+            description = 'Ingest: Document processing script to parse the document and create embeddings locally'
+            arguments = [
+                {
+                    'args': ['--persist_dir'],
+                    'kwargs': {'metavar': 'DIRECTORY_PATH', 'type': str, 'help': 'Directory to persist data'}
+                },
+                {
+                    'args': ['--source_dir'],
+                    'kwargs': {'metavar': 'DIRECTORY_PATH', 'type': str, 'help': 'Directory for source documents'}
+                },
+                {
+                    'args': ['--embeddings_model'],
+                    'kwargs': {'metavar': 'MODEL_NAME', 'type': str, 'help': 'Name of the embeddings model'}
+                },
+            ]
+        else:
+            raise ValueError(f"Unknown type: {type}")
+
+        return ArgsHandler.parse_args(description, arguments)

--- a/ingest.py
+++ b/ingest.py
@@ -25,15 +25,17 @@ from langchain.vectorstores import Chroma
 from langchain.embeddings import HuggingFaceEmbeddings
 from langchain.docstore.document import Document
 from constants import CHROMA_SETTINGS
+from argsHandler import ArgsHandler
 
 
 load_dotenv()
+# Parse the command line arguments
+args = ArgsHandler.get_args(ArgsHandler.INGEST)
 
-
-# Load environment variables
-persist_directory = os.environ.get('PERSIST_DIRECTORY')
-source_directory = os.environ.get('SOURCE_DIRECTORY', 'source_documents')
-embeddings_model_name = os.environ.get('EMBEDDINGS_MODEL_NAME')
+# Load environment variables or use console arguments
+persist_directory = os.environ.get('PERSIST_DIRECTORY') if args.persist_dir is None else args.persist_dir
+source_directory = os.environ.get('SOURCE_DIRECTORY','source_documents') if args.source_dir is None else args.source_dir
+embeddings_model_name = os.environ.get('EMBEDDINGS_MODEL_NAME') if args.embeddings_model is None else args.embeddings_model
 chunk_size = 500
 chunk_overlap = 50
 

--- a/privateGPT.py
+++ b/privateGPT.py
@@ -5,8 +5,8 @@ from langchain.embeddings import HuggingFaceEmbeddings
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.vectorstores import Chroma
 from langchain.llms import GPT4All, LlamaCpp
+from argsHandler import ArgsHandler
 import os
-import argparse
 
 load_dotenv()
 
@@ -16,13 +16,13 @@ persist_directory = os.environ.get('PERSIST_DIRECTORY')
 model_type = os.environ.get('MODEL_TYPE')
 model_path = os.environ.get('MODEL_PATH')
 model_n_ctx = os.environ.get('MODEL_N_CTX')
-target_source_chunks = int(os.environ.get('TARGET_SOURCE_CHUNKS',4))
+target_source_chunks = int(os.environ.get('TARGET_SOURCE_CHUNKS', 4))
 
 from constants import CHROMA_SETTINGS
 
 def main():
     # Parse the command line arguments
-    args = parse_arguments()
+    args = ArgsHandler.get_args(ArgsHandler.PRIVATE_GPT)
     embeddings = HuggingFaceEmbeddings(model_name=embeddings_model_name)
     db = Chroma(persist_directory=persist_directory, embedding_function=embeddings, client_settings=CHROMA_SETTINGS)
     retriever = db.as_retriever(search_kwargs={"k": target_source_chunks})
@@ -58,18 +58,6 @@ def main():
         for document in docs:
             print("\n> " + document.metadata["source"] + ":")
             print(document.page_content)
-
-def parse_arguments():
-    parser = argparse.ArgumentParser(description='privateGPT: Ask questions to your documents without an internet connection, '
-                                                 'using the power of LLMs.')
-    parser.add_argument("--hide-source", "-S", action='store_true',
-                        help='Use this flag to disable printing of source documents used for answers.')
-
-    parser.add_argument("--mute-stream", "-M",
-                        action='store_true',
-                        help='Use this flag to disable the streaming StdOut callback for LLMs.')
-
-    return parser.parse_args()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added support for CLI args for ingest as per the suggestion brought up by @PulpCattel on PR #312 

Additionally, this refactor aims to make the management of command line arguments more streamlined, and any future changes to argument parsing can now be done in one place.

1. Created a new module which is responsible for parsing command line arguments for multiple scripts to improv the maintainability and consistency across scripts.

2. Refactored `privateGPT.py` and `ingest.py` to use the new module for argument parsing. Removed individual argument parsing logic from these scripts.