### PR TITLE
Let ingestion continue when any issue happens in any source document

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -84,9 +84,12 @@ LOADER_MAPPING = {
 def load_single_document(file_path: str) -> List[Document]:
     ext = "." + file_path.rsplit(".", 1)[-1]
     if ext in LOADER_MAPPING:
-        loader_class, loader_args = LOADER_MAPPING[ext]
-        loader = loader_class(file_path, **loader_args)
-        return loader.load()
+        try:
+          loader_class, loader_args = LOADER_MAPPING[ext]
+          loader = loader_class(file_path, **loader_args)
+          return loader.load()
+        except Exception as e:
+          return {'exception':e, 'file':file_path}
 
     raise ValueError(f"Unsupported file extension '{ext}'")
 
@@ -105,6 +108,9 @@ def load_documents(source_dir: str, ignored_files: List[str] = []) -> List[Docum
         results = []
         with tqdm(total=len(filtered_files), desc='Loading new documents', ncols=80) as pbar:
             for i, docs in enumerate(pool.imap_unordered(load_single_document, filtered_files)):
+                if isinstance(docs, dict):
+                    print(" - " + docs['file'] + ": ERROR: " + str(docs['exception']))
+                    continue
                 results.extend(docs)
                 pbar.update()
 


### PR DESCRIPTION
Currently any issue in any document will halt the entire ingestion process, as mentioned in issue #442.

This change allows it to continue ingesting later files, while logging which files were problematic and the reason.