### PR TITLE
Create documentation website with write-the

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,23 @@
+
+name: mkdocs 
+on:
+  push:
+    branches:
+      - master 
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - uses: actions/cache@v2
+        with:
+          key: ${{ github.ref }}
+          path: .cache
+      - run: pip install "mkdocstrings[python]" "mkdocs-material"
+      - run: mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,137 @@
+---
+title: Home
+---
+# privateGPT
+Ask questions to your documents without an internet connection, using the power of LLMs. 100% private, no data leaves your execution environment at any point. You can ingest documents and ask questions without an internet connection!
+
+Built with [LangChain](https://github.com/hwchase17/langchain), [GPT4All](https://github.com/nomic-ai/gpt4all), [LlamaCpp](https://github.com/ggerganov/llama.cpp), [Chroma](https://www.trychroma.com/) and [SentenceTransformers](https://www.sbert.net/).
+
+<img width="902" alt="demo" src="https://user-images.githubusercontent.com/721666/236942256-985801c9-25b9-48ef-80be-3acbb4575164.png">
+
+# Environment Setup
+In order to set your environment up to run the code here, first install all requirements:
+
+```shell
+pip3 install -r requirements.txt
+```
+
+Then, download the LLM model and place it in a directory of your choice:
+- LLM: default to [ggml-gpt4all-j-v1.3-groovy.bin](https://gpt4all.io/models/ggml-gpt4all-j-v1.3-groovy.bin). If you prefer a different GPT4All-J compatible model, just download it and reference it in your `.env` file.
+
+Rename `example.env` to `.env` and edit the variables appropriately.
+```
+MODEL_TYPE: supports LlamaCpp or GPT4All
+PERSIST_DIRECTORY: is the folder you want your vectorstore in
+MODEL_PATH: Path to your GPT4All or LlamaCpp supported LLM
+MODEL_N_CTX: Maximum token limit for the LLM model
+EMBEDDINGS_MODEL_NAME: SentenceTransformers embeddings model name (see https://www.sbert.net/docs/pretrained_models.html)
+TARGET_SOURCE_CHUNKS: The amount of chunks (sources) that will be used to answer a question
+```
+
+Note: because of the way `langchain` loads the `SentenceTransformers` embeddings, the first time you run the script it will require internet connection to download the embeddings model itself.
+
+## Test dataset
+This repo uses a [state of the union transcript](https://github.com/imartinez/privateGPT/blob/main/source_documents/state_of_the_union.txt) as an example.
+
+## Instructions for ingesting your own dataset
+
+Put any and all your files into the `source_documents` directory
+
+The supported extensions are:
+
+   - `.csv`: CSV,
+   - `.docx`: Word Document,
+   - `.doc`: Word Document,
+   - `.enex`: EverNote,
+   - `.eml`: Email,
+   - `.epub`: EPub,
+   - `.html`: HTML File,
+   - `.md`: Markdown,
+   - `.msg`: Outlook Message,
+   - `.odt`: Open Document Text,
+   - `.pdf`: Portable Document Format (PDF),
+   - `.pptx` : PowerPoint Document,
+   - `.ppt` : PowerPoint Document,
+   - `.txt`: Text file (UTF-8),
+
+Run the following command to ingest all the data.
+
+```shell
+python ingest.py
+```
+
+Output should look like this:
+
+```shell
+Creating new vectorstore
+Loading documents from source_documents
+Loading new documents: 100%|██████████████████████| 1/1 [00:01<00:00,  1.73s/it]
+Loaded 1 new documents from source_documents
+Split into 90 chunks of text (max. 500 tokens each)
+Creating embeddings. May take some minutes...
+Using embedded DuckDB with persistence: data will be stored in: db
+Ingestion complete! You can now run privateGPT.py to query your documents
+```
+
+It will create a `db` folder containing the local vectorstore. Will take 20-30 seconds per document, depending on the size of the document.
+You can ingest as many documents as you want, and all will be accumulated in the local embeddings database.
+If you want to start from an empty database, delete the `db` folder.
+
+Note: during the ingest process no data leaves your local environment. You could ingest without an internet connection, except for the first time you run the ingest script, when the embeddings model is downloaded.
+
+## Ask questions to your documents, locally!
+In order to ask a question, run a command like:
+
+```shell
+python privateGPT.py
+```
+
+And wait for the script to require your input.
+
+```plaintext
+> Enter a query:
+```
+
+Hit enter. You'll need to wait 20-30 seconds (depending on your machine) while the LLM model consumes the prompt and prepares the answer. Once done, it will print the answer and the 4 sources it used as context from your documents; you can then ask another question without re-running the script, just wait for the prompt again.
+
+Note: you could turn off your internet connection, and the script inference would still work. No data gets out of your local environment.
+
+Type `exit` to finish the script.
+
+
+### CLI
+The script also supports optional command-line arguments to modify its behavior. You can see a full list of these arguments by running the command ```python privateGPT.py --help``` in your terminal.
+
+
+# How does it work?
+Selecting the right local models and the power of `LangChain` you can run the entire pipeline locally, without any data leaving your environment, and with reasonable performance.
+
+- `ingest.py` uses `LangChain` tools to parse the document and create embeddings locally using `HuggingFaceEmbeddings` (`SentenceTransformers`). It then stores the result in a local vector database using `Chroma` vector store.
+- `privateGPT.py` uses a local LLM based on `GPT4All-J` or `LlamaCpp` to understand questions and create answers. The context for the answers is extracted from the local vector store using a similarity search to locate the right piece of context from the docs.
+- `GPT4All-J` wrapper was introduced in LangChain 0.0.162.
+
+# System Requirements
+
+## Python Version
+To use this software, you must have Python 3.10 or later installed. Earlier versions of Python will not compile.
+
+## C++ Compiler
+If you encounter an error while building a wheel during the `pip install` process, you may need to install a C++ compiler on your computer.
+
+### For Windows 10/11
+To install a C++ compiler on Windows 10/11, follow these steps:
+
+1. Install Visual Studio 2022.
+2. Make sure the following components are selected:
+   * Universal Windows Platform development
+   * C++ CMake tools for Windows
+3. Download the MinGW installer from the [MinGW website](https://sourceforge.net/projects/mingw/).
+4. Run the installer and select the `gcc` component.
+
+## Mac Running Intel
+When running a Mac with Intel hardware (not M1), you may run into _clang: error: the clang compiler does not support '-march=native'_ during pip install.
+
+If so set your archflags during pip install. eg: _ARCHFLAGS="-arch x86_64" pip3 install -r requirements.txt_
+
+# Disclaimer
+This is a test project to validate the feasibility of a fully private solution for question answering using LLMs and Vector embeddings. It is not production ready, and it is not meant to be used in production. The models selection is not optimized for performance, but for privacy; but it is possible to use different models and vectorstores to improve performance.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,6 @@
+::: privateGPT
+
+::: ingest
+
+::: constants
+

--- a/ingest.py
+++ b/ingest.py
@@ -40,10 +40,24 @@ chunk_overlap = 50
 
 # Custom document loaders
 class MyElmLoader(UnstructuredEmailLoader):
-    """Wrapper to fallback to text/plain when default does not work"""
+    """
+    Wrapper to fallback to text/plain when default does not work.
+    """
 
     def load(self) -> List[Document]:
-        """Wrapper adding fallback for elm without html"""
+        """
+        Wrapper adding fallback for elm without html.
+        Args:
+            self (MyElmLoader): The MyElmLoader instance.
+        Returns:
+            List[Document]: The list of documents.
+        Raises:
+            ValueError: If an unsupported file extension is encountered.
+        Examples:
+            >>> MyElmLoader.load(self)
+            [Document]
+        """
+
         try:
             try:
                 doc = UnstructuredEmailLoader.load(self)
@@ -82,6 +96,18 @@ LOADER_MAPPING = {
 
 
 def load_single_document(file_path: str) -> List[Document]:
+    """
+    Loads a single document from a file path.
+    Args:
+      file_path (str): The file path of the document.
+    Returns:
+      List[Document]: The list of documents.
+    Raises:
+      ValueError: If an unsupported file extension is encountered.
+    Examples:
+      >>> load_single_document('example.txt')
+      [Document]
+    """
     ext = "." + file_path.rsplit(".", 1)[-1]
     if ext in LOADER_MAPPING:
         loader_class, loader_args = LOADER_MAPPING[ext]
@@ -92,7 +118,15 @@ def load_single_document(file_path: str) -> List[Document]:
 
 def load_documents(source_dir: str, ignored_files: List[str] = []) -> List[Document]:
     """
-    Loads all documents from the source documents directory, ignoring specified files
+    Loads all documents from the source documents directory, ignoring specified files.
+    Args:
+      source_dir (str): The source directory of the documents.
+      ignored_files (List[str], optional): The list of files to ignore. Defaults to [].
+    Returns:
+      List[Document]: The list of documents.
+    Examples:
+      >>> load_documents('source_documents', ['example.txt'])
+      [Document]
     """
     all_files = []
     for ext in LOADER_MAPPING:
@@ -112,7 +146,14 @@ def load_documents(source_dir: str, ignored_files: List[str] = []) -> List[Docum
 
 def process_documents(ignored_files: List[str] = []) -> List[Document]:
     """
-    Load documents and split in chunks
+    Load documents and split in chunks.
+    Args:
+      ignored_files (List[str], optional): The list of files to ignore. Defaults to [].
+    Returns:
+      List[Document]: The list of documents.
+    Examples:
+      >>> process_documents(['example.txt'])
+      [Document]
     """
     print(f"Loading documents from {source_directory}")
     documents = load_documents(source_directory, ignored_files)
@@ -127,7 +168,14 @@ def process_documents(ignored_files: List[str] = []) -> List[Document]:
 
 def does_vectorstore_exist(persist_directory: str) -> bool:
     """
-    Checks if vectorstore exists
+    Checks if vectorstore exists.
+    Args:
+      persist_directory (str): The directory of the vectorstore.
+    Returns:
+      bool: True if vectorstore exists, False otherwise.
+    Examples:
+      >>> does_vectorstore_exist('persist_directory')
+      True
     """
     if os.path.exists(os.path.join(persist_directory, 'index')):
         if os.path.exists(os.path.join(persist_directory, 'chroma-collections.parquet')) and os.path.exists(os.path.join(persist_directory, 'chroma-embeddings.parquet')):
@@ -139,6 +187,12 @@ def does_vectorstore_exist(persist_directory: str) -> bool:
     return False
 
 def main():
+    """
+    Create embeddings, check if vectorstore exists, and update/create vectorstore.
+    Examples:
+      >>> main()
+      Ingestion complete! You can now run privateGPT.py to query your documents
+    """
     # Create embeddings
     embeddings = HuggingFaceEmbeddings(model_name=embeddings_model_name)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,31 @@
+
+site_name: PrivateGPT
+repo_url: https://github.com/imartinez/privateGPT
+
+theme:
+  name: "material"
+  homepage: https://github.com/imartinez/privateGPT
+  # logo: assets/logo.png
+  # favicon: images/favicon.png
+  palette: 
+    - scheme: default
+      toggle:
+        icon: material/brightness-7 
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - toc.follow
+    - content.action.edit
+
+extra:
+  social:
+    - icon: fontawesome/solid/robot
+      link: https://github.com/Wytamma/write-the
+      name: Generated with write-the
+
+plugins:
+- search
+- mkdocstrings

--- a/privateGPT.py
+++ b/privateGPT.py
@@ -21,6 +21,22 @@ target_source_chunks = int(os.environ.get('TARGET_SOURCE_CHUNKS',4))
 from constants import CHROMA_SETTINGS
 
 def main():
+    """
+    Runs the main program.
+    Args:
+      None
+    Returns:
+      None
+    Side Effects:
+      Prompts the user for a query and prints the answer and source documents.
+    Examples:
+      >>> main()
+      Enter a query: What is the capital of France?
+      > Question:
+      What is the capital of France?
+      > Answer:
+      Paris
+    """
     # Parse the command line arguments
     args = parse_arguments()
     embeddings = HuggingFaceEmbeddings(model_name=embeddings_model_name)
@@ -60,6 +76,18 @@ def main():
             print(document.page_content)
 
 def parse_arguments():
+    """
+    Parses the command line arguments.
+    Args:
+      None
+    Returns:
+      argparse.Namespace: The parsed arguments.
+    Side Effects:
+      None
+    Examples:
+      >>> parse_arguments()
+      Namespace(hide_source=False, mute_stream=False)
+    """
     parser = argparse.ArgumentParser(description='privateGPT: Ask questions to your documents without an internet connection, '
                                                  'using the power of LLMs.')
     parser.add_argument("--hide-source", "-S", action='store_true',


### PR DESCRIPTION
Hi @imartinez,

I used `write-the` (https://github.com/wytamma/write-the) to create a mkdocs website for privateGPT (API reference included). Write-the uses OpenAI's GPT models to document the source code and build the website. I used the commands `write-the docs` and `write-the mkdocs` to create the documentation site for privateGPT. You can see a demo of the site here -> [https://blog.wytamma.com/privateGPT](https://blog.wytamma.com/privateGPT/). 

I've attached screenshots:
![Screenshot 1](https://github.com/imartinez/privateGPT/assets/13726005/72ff278d-1ed5-4e3e-ad84-60839a4000c8)
![Screenshot 2](https://github.com/imartinez/privateGPT/assets/13726005/e6cf388c-b26e-430e-a1a9-78aa05f278a5)

You can use [Github Pages](https://pages.github.com/) to host the site for free. You just have to enable the setting to deploy form the `gh-pages` branch (managed automatically by the [.github/workflows/mkdocs.yml](https://github.com/imartinez/privateGPT/compare/main...Wytamma:privateGPT:main?expand=1#diff-ac5175ca62288ff3d3d57d7f315390766083f9a99e21f56d709026e10114a551) file).

![Screenshot 2023-06-06 at 3 03 27 pm](https://github.com/imartinez/privateGPT/assets/13726005/217d3ea8-fafb-43fd-8f98-d2ab712e5f6d)