### PR TITLE
Update gpt4all to 0.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 langchain==0.0.197
-gpt4all==0.3.2
+gpt4all==0.3.4
 chromadb==0.3.23
 llama-cpp-python==0.1.50
 urllib3==2.0.2


### PR DESCRIPTION
gpt4all==0.3.2 was yanked according to https://pypi.org/project/gpt4all/#historyi

Ties to issue 691: https://github.com/imartinez/privateGPT/issues/691