### PR TITLE
raise exception instead of print & exit

### DIFF
--- a/privateGPT.py
+++ b/privateGPT.py
@@ -37,8 +37,9 @@ def main():
         case "GPT4All":
             llm = GPT4All(model=model_path, n_ctx=model_n_ctx, backend='gptj', n_batch=model_n_batch, callbacks=callbacks, verbose=False)
         case _default:
-            print(f"Model {model_type} not supported!")
-            exit;
+            # raise exception if model_type is not supported
+            raise Exception(f"Model type {model_type} is not supported. Please choose one of the following: LlamaCpp, GPT4All")
+        
     qa = RetrievalQA.from_chain_type(llm=llm, chain_type="stuff", retriever=retriever, return_source_documents= not args.hide_source)
     # Interactive questions and answers
     while True:


### PR DESCRIPTION
It's better to raise an exception to handle the error more gracefully than abruptly exiting the script.