### PR TITLE
Better error message if .env is empty/does not exist.

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -6,6 +6,8 @@ load_dotenv()
 
 # Define the folder for storing database
 PERSIST_DIRECTORY = os.environ.get('PERSIST_DIRECTORY')
+if PERSIST_DIRECTORY is None:
+    raise Exception("Please set the PERSIST_DIRECTORY environment variable")
 
 # Define the Chroma settings
 CHROMA_SETTINGS = Settings(

--- a/ingest.py
+++ b/ingest.py
@@ -24,11 +24,12 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.vectorstores import Chroma
 from langchain.embeddings import HuggingFaceEmbeddings
 from langchain.docstore.document import Document
+
+if not load_dotenv():
+    print("Could not load .env file or it is empty. Please check if it exists and is readable.")
+    exit(1)
+
 from constants import CHROMA_SETTINGS
-
-
-load_dotenv()
-
 
 # Load environment variables
 persist_directory = os.environ.get('PERSIST_DIRECTORY')

--- a/privateGPT.py
+++ b/privateGPT.py
@@ -9,7 +9,9 @@ import os
 import argparse
 import time
 
-load_dotenv()
+if not load_dotenv():
+    print("Could not load .env file or it is empty. Please check if it exists and is readable.")
+    exit(1)
 
 embeddings_model_name = os.environ.get("EMBEDDINGS_MODEL_NAME")
 persist_directory = os.environ.get('PERSIST_DIRECTORY')
@@ -39,7 +41,7 @@ def main():
         case _default:
             # raise exception if model_type is not supported
             raise Exception(f"Model type {model_type} is not supported. Please choose one of the following: LlamaCpp, GPT4All")
-        
+
     qa = RetrievalQA.from_chain_type(llm=llm, chain_type="stuff", retriever=retriever, return_source_documents= not args.hide_source)
     # Interactive questions and answers
     while True:


### PR DESCRIPTION
Instead of 
```
Traceback (most recent call last):
  File "/home/xxx/privateGPT/ingest.py", line 27, in <module>
    from constants import CHROMA_SETTINGS
  File "/home/xxx/privateGPT/constants.py", line 11, in <module>
    CHROMA_SETTINGS = Settings(
                      ^^^^^^^^^
  File "pydantic/env_settings.py", line 40, in pydantic.env_settings.BaseSettings.__init__
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Settings
persist_directory
  none is not an allowed value (type=type_error.none.not_allowed)
```

get a nice
```
Could not load .env file or it is empty. Please check if it exists and is readable.
```

or 
```
Please set the PERSIST_DIRECTORY environment variable
```