### PR TITLE
Fixing Llamacpp context size bug

### DIFF
--- a/privateGPT.py
+++ b/privateGPT.py
@@ -33,7 +33,7 @@ def main():
     # Prepare the LLM
     match model_type:
         case "LlamaCpp":
-            llm = LlamaCpp(model_path=model_path, max_tokens=model_n_ctx, n_batch=model_n_batch, callbacks=callbacks, verbose=False)
+            llm = LlamaCpp(model_path=model_path, n_ctx=model_n_ctx, n_batch=model_n_batch, callbacks=callbacks, verbose=False)
         case "GPT4All":
             llm = GPT4All(model=model_path, max_tokens=model_n_ctx, backend='gptj', n_batch=model_n_batch, callbacks=callbacks, verbose=False)
         case _default:

--- a/privateGPT.py
+++ b/privateGPT.py
@@ -17,6 +17,8 @@ persist_directory = os.environ.get('PERSIST_DIRECTORY')
 model_type = os.environ.get('MODEL_TYPE')
 model_path = os.environ.get('MODEL_PATH')
 model_n_ctx = os.environ.get('MODEL_N_CTX')
+model_n_gpu_layers = os.environ.get('MODEL_N_GPU_LAYERS')
+model_n_threads = os.environ.get('MODEL_N_THREADS')
 model_n_batch = int(os.environ.get('MODEL_N_BATCH',8))
 target_source_chunks = int(os.environ.get('TARGET_SOURCE_CHUNKS',4))
 
@@ -33,7 +35,7 @@ def main():
     # Prepare the LLM
     match model_type:
         case "LlamaCpp":
-            llm = LlamaCpp(model_path=model_path, n_ctx=model_n_ctx, n_batch=model_n_batch, callbacks=callbacks, verbose=False)
+            llm = LlamaCpp(model_path=model_path, max_tokens=model_n_ctx, n_ctx=model_n_ctx, n_batch=model_n_batch, callbacks=callbacks, verbose=False, n_gpu_layers=model_n_gpu_layers, n_threads=model_n_threads)
         case "GPT4All":
             llm = GPT4All(model=model_path, max_tokens=model_n_ctx, backend='gptj', n_batch=model_n_batch, callbacks=callbacks, verbose=False)
         case _default:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tabulate==0.9.0
 pandoc==2.3
 pypandoc==1.11
 tqdm==4.65.0
+sentence_transformers==2.2.2


### PR DESCRIPTION
I have noticed that changing MODEL_N_CTX wasn't changing the way the models were loaded in llamacpp. This is particularly obvious now with the larger llama2 context sizes. After some digging I found that this was down to the parameter being passed to langchain. That is what this pull request fixes. I have tested it and it is working as it should for llama2-chat models. 