### PR TITLE
Add_sentence_transformers_2.2.2_to_required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tabulate==0.9.0
 pandoc==2.3
 pypandoc==1.11
 tqdm==4.65.0
+sentence_transformers==2.2.2


### PR DESCRIPTION
Adding sentence_transformers to requirements.txt. Two different computers had an issue and pip told me to install this in order to resolve the problem. Fix worked for both computers on python3 