### PR TITLE
Prem: supports multiple models and vectorstores

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ The script also supports optional command-line arguments to modify its behavior.
 
 Provide `--backend` argument for both `ingest.py` and `privateGPT.py` to use a different backend. Currently supported backends are `prem` or `default`.
 
+E.g., to use `prem` backend:
+
+```bash
+ptyhon ingest.py --backend prem
+python privateGPT.py --backend prem
+```
+
 ### Backends
 
 - `default`: uses purely Python to interact and expose the models.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Type `exit` to finish the script.
 ### CLI
 The script also supports optional command-line arguments to modify its behavior. You can see a full list of these arguments by running the command ```python privateGPT.py --help``` in your terminal.
 
+## Multiple Private Backends Support
+
+Provide `--backend` argument for both `ingest.py` and `privateGPT.py` to use a different backend. Currently supported backends are `prem` or `default`.
+
+### Backends
+
+- `default`: uses purely Python to interact and expose the models.
+- `prem`: uses [Prem](https://github.com/premAI-io/prem-app) in order to expose and serve the models with Docker. The `ingest.py` and `privateGPT.py` scripts are modified to use Prem as a backend. Check [here](https://dev.premai.io/docs/intro) to learn how to install and use Prem.
 
 # How does it work?
 Selecting the right local models and the power of `LangChain` you can run the entire pipeline locally, without any data leaving your environment, and with reasonable performance.

--- a/privateGPT.py
+++ b/privateGPT.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 from dotenv import load_dotenv
+from langchain.chat_models import ChatOpenAI
 from langchain.chains import RetrievalQA
-from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.embeddings import HuggingFaceEmbeddings, OpenAIEmbeddings
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.vectorstores import Chroma
 from langchain.llms import GPT4All, LlamaCpp
+from langchain.vectorstores.redis import Redis
 import os
 import argparse
 import time
@@ -20,27 +22,39 @@ model_n_ctx = os.environ.get('MODEL_N_CTX')
 model_n_batch = int(os.environ.get('MODEL_N_BATCH',8))
 target_source_chunks = int(os.environ.get('TARGET_SOURCE_CHUNKS',4))
 
+os.environ["OPENAI_API_KEY"] = "random-string"
+redis_url = "redis://localhost:6379"
+
 from constants import CHROMA_SETTINGS
 
 def main():
     # Parse the command line arguments
     args = parse_arguments()
-    embeddings = HuggingFaceEmbeddings(model_name=embeddings_model_name)
-    db = Chroma(persist_directory=persist_directory, embedding_function=embeddings, client_settings=CHROMA_SETTINGS)
-    retriever = db.as_retriever(search_kwargs={"k": target_source_chunks})
-    # activate/deactivate the streaming StdOut callback for LLMs
-    callbacks = [] if args.mute_stream else [StreamingStdOutCallbackHandler()]
-    # Prepare the LLM
-    match model_type:
-        case "LlamaCpp":
-            llm = LlamaCpp(model_path=model_path, max_tokens=model_n_ctx, n_batch=model_n_batch, callbacks=callbacks, verbose=False)
-        case "GPT4All":
-            llm = GPT4All(model=model_path, max_tokens=model_n_ctx, backend='gptj', n_batch=model_n_batch, callbacks=callbacks, verbose=False)
-        case _default:
-            # raise exception if model_type is not supported
-            raise Exception(f"Model type {model_type} is not supported. Please choose one of the following: LlamaCpp, GPT4All")
+
+    if args.backend == "prem":
+        llm = ChatOpenAI(openai_api_base="http://localhost:8111/v1", max_tokens=128)
+        embeddings = OpenAIEmbeddings(openai_api_base="http://localhost:8444/v1")
+        db = Redis(redis_url=redis_url, embedding_function=embeddings.embed_query, index_name="prem_private_gpt")
+        retriever = db.as_retriever(search_kwargs={"k": target_source_chunks})
+
+    else:
+        embeddings = HuggingFaceEmbeddings(model_name=embeddings_model_name)
+        db = Chroma(persist_directory=persist_directory, embedding_function=embeddings, client_settings=CHROMA_SETTINGS)
+        retriever = db.as_retriever(search_kwargs={"k": target_source_chunks})
+        # activate/deactivate the streaming StdOut callback for LLMs
+        callbacks = [] if args.mute_stream else [StreamingStdOutCallbackHandler()]
+        # Prepare the LLM
+        match model_type:
+            case "LlamaCpp":
+                llm = LlamaCpp(model_path=model_path, max_tokens=model_n_ctx, n_batch=model_n_batch, callbacks=callbacks, verbose=False)
+            case "GPT4All":
+                llm = GPT4All(model=model_path, max_tokens=model_n_ctx, backend='gptj', n_batch=model_n_batch, callbacks=callbacks, verbose=False)
+            case _default:
+                # raise exception if model_type is not supported
+                raise Exception(f"Model type {model_type} is not supported. Please choose one of the following: LlamaCpp, GPT4All")
         
     qa = RetrievalQA.from_chain_type(llm=llm, chain_type="stuff", retriever=retriever, return_source_documents= not args.hide_source)
+    
     # Interactive questions and answers
     while True:
         query = input("\nEnter a query: ")
@@ -76,6 +90,9 @@ def parse_arguments():
                         action='store_true',
                         help='Use this flag to disable the streaming StdOut callback for LLMs.')
 
+    parser.add_argument("--backend", "-B",
+                        type=str,
+                        help='Use this flag to change backend.')
     return parser.parse_args()
 
 

--- a/privateGPT.py
+++ b/privateGPT.py
@@ -36,6 +36,7 @@ def main():
         embeddings = OpenAIEmbeddings(openai_api_base="http://localhost:8444/v1")
         db = Redis(redis_url=redis_url, embedding_function=embeddings.embed_query, index_name="prem_private_gpt")
         retriever = db.as_retriever(search_kwargs={"k": target_source_chunks})
+        retriever.k = 1
 
     else:
         embeddings = HuggingFaceEmbeddings(model_name=embeddings_model_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ tabulate==0.9.0
 pandoc==2.3
 pypandoc==1.11
 tqdm==4.65.0
+redis==5.0.0
+openai==0.27.8
+tiktoken==0.4.0


### PR DESCRIPTION
Enabling [Prem](https://github.com/premAI-io/prem-app) backend support gives out-of-the-box all the models packaged in the [Prem ecosystem](https://registry.premai.io/).

- It doesn't change the current PrivateGPT architecture. No breaking changes.
- Optional parameter (`--backend`) for enabling connection to Prem App running locally on your MacOS with Docker.