### PR TITLE
Improve logging and error handling when ingesting an entire folder

### DIFF
--- a/docs/description.md
+++ b/docs/description.md
@@ -416,6 +416,12 @@ and optionally watch changes on it with the command:
 make ingest /path/to/folder -- --watch
 ```
 
+To log the processed and failed files to an additional file, use:
+
+```bash
+make ingest /path/to/folder -- --watch --log-file /path/to/log/file.log
+```
+
 After ingestion is complete, you should be able to chat with your documents
 by navigating to http://localhost:8001 and using the option `Query documents`,
 or using the completions / chat API.

--- a/scripts/ingest_folder.py
+++ b/scripts/ingest_folder.py
@@ -1,7 +1,8 @@
 import argparse
-from loguru import logger
 import sys
 from pathlib import Path
+
+from loguru import logger
 
 from private_gpt.di import root_injector
 from private_gpt.server.ingest.ingest_service import IngestService
@@ -21,7 +22,7 @@ parser.add_argument(
     "--log-file",
     help="Optional path to a log file. If provided, logs will be written to this file.",
     type=str,
-    default=None
+    default=None,
 )
 args = parser.parse_args()
 
@@ -29,7 +30,11 @@ args = parser.parse_args()
 # Remove pre-configured logging handler
 logger.remove(0)
 # For console colorized output without line and function info:
-logger.add(sys.stdout, level="INFO", colorize=True, format=(
+logger.add(
+    sys.stdout,
+    level="INFO",
+    colorize=True,
+    format=(
         "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
         "<level>{level: <8}</level> | "
         "<level>{message}</level>"
@@ -37,13 +42,18 @@ logger.add(sys.stdout, level="INFO", colorize=True, format=(
 )
 # For file output, using a clear and timestamped format:
 if args.log_file:
-    logger.add(args.log_file, rotation="10 MB", level="INFO", format="[{time:YYYY-MM-DD HH:mm:ss}] [{level}] {message}")
+    logger.add(
+        args.log_file,
+        rotation="10 MB",
+        level="INFO",
+        format="[{time:YYYY-MM-DD HH:mm:ss}] [{level}] {message}",
+    )
 
 total_documents = 0
 current_document_count = 0
 
 
-def count_documents(folder_path: Path) -> int:
+def count_documents(folder_path: Path) -> None:
     global total_documents
     for file_path in folder_path.iterdir():
         if file_path.is_file():

--- a/scripts/ingest_folder.py
+++ b/scripts/ingest_folder.py
@@ -1,4 +1,5 @@
 import argparse
+from loguru import logger
 import sys
 from pathlib import Path
 
@@ -8,7 +9,6 @@ from private_gpt.server.ingest.ingest_watcher import IngestWatcher
 
 ingest_service = root_injector.get(IngestService)
 
-
 parser = argparse.ArgumentParser(prog="ingest_folder.py")
 parser.add_argument("folder", help="Folder to ingest")
 parser.add_argument(
@@ -17,29 +17,72 @@ parser.add_argument(
     action=argparse.BooleanOptionalAction,
     default=False,
 )
+parser.add_argument(
+    "--log-file",
+    help="Optional path to a log file. If provided, logs will be written to this file.",
+    type=str,
+    default=None
+)
 args = parser.parse_args()
+
+# Set up loguru logging
+# Remove pre-configured logging handler
+logger.remove(0)
+# For console colorized output without line and function info:
+logger.add(sys.stdout, level="INFO", colorize=True, format=(
+        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
+        "<level>{level: <8}</level> | "
+        "<level>{message}</level>"
+    ),
+)
+# For file output, using a clear and timestamped format:
+if args.log_file:
+    logger.add(args.log_file, rotation="10 MB", level="INFO", format="[{time:YYYY-MM-DD HH:mm:ss}] [{level}] {message}")
+
+total_documents = 0
+current_document_count = 0
+
+
+def count_documents(folder_path: Path) -> int:
+    global total_documents
+    for file_path in folder_path.iterdir():
+        if file_path.is_file():
+            total_documents += 1
+        elif file_path.is_dir():
+            count_documents(file_path)
 
 
 def _recursive_ingest_folder(folder_path: Path) -> None:
+    global current_document_count, total_documents
     for file_path in folder_path.iterdir():
         if file_path.is_file():
+            current_document_count += 1
+            progress_msg = f"Document {current_document_count} of {total_documents} ({(current_document_count / total_documents) * 100:.2f}%)"
+            logger.info(progress_msg)
             _do_ingest(file_path)
         elif file_path.is_dir():
             _recursive_ingest_folder(file_path)
 
 
 def _do_ingest(changed_path: Path) -> None:
-    if changed_path.exists():
-        print(f"\nIngesting {changed_path}")
-        ingest_service.ingest(changed_path.name, changed_path)
+    try:
+        if changed_path.exists():
+            logger.info(f"Started ingesting {changed_path}")
+            ingest_service.ingest(changed_path.name, changed_path)
+            logger.info(f"Completed ingesting {changed_path}")
+    except Exception as e:
+        logger.error(f"Failed to ingest document: {changed_path}. Error: {e}")
 
 
 path = Path(args.folder)
 if not path.exists():
     raise ValueError(f"Path {args.folder} does not exist")
 
+# Count total documents before ingestion
+count_documents(path)
+
 _recursive_ingest_folder(path)
 if args.watch:
-    print(f"Watching {args.folder} for changes, press Ctrl+C to stop...")
+    logger.info(f"Watching {args.folder} for changes, press Ctrl+C to stop...")
     watcher = IngestWatcher(args.folder, _do_ingest)
     watcher.start()

--- a/scripts/ingest_folder.py
+++ b/scripts/ingest_folder.py
@@ -1,12 +1,12 @@
 import argparse
-import sys
+import logging
 from pathlib import Path
-
-from loguru import logger
 
 from private_gpt.di import root_injector
 from private_gpt.server.ingest.ingest_service import IngestService
 from private_gpt.server.ingest.ingest_watcher import IngestWatcher
+
+logger = logging.getLogger(__name__)
 
 ingest_service = root_injector.get(IngestService)
 
@@ -26,28 +26,17 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-# Set up loguru logging
-# Remove pre-configured logging handler
-logger.remove(0)
-# For console colorized output without line and function info:
-logger.add(
-    sys.stdout,
-    level="INFO",
-    colorize=True,
-    format=(
-        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
-        "<level>{level: <8}</level> | "
-        "<level>{message}</level>"
-    ),
-)
-# For file output, using a clear and timestamped format:
+# Set up logging to a file if a path is provided
 if args.log_file:
-    logger.add(
-        args.log_file,
-        rotation="10 MB",
-        level="INFO",
-        format="[{time:YYYY-MM-DD HH:mm:ss}] [{level}] {message}",
+    file_handler = logging.FileHandler(args.log_file, mode="a")
+    file_handler.setFormatter(
+        logging.Formatter(
+            "[%(asctime)s.%(msecs)03d] [%(levelname)s] %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
     )
+    logger.addHandler(file_handler)
+
 
 total_documents = 0
 current_document_count = 0


### PR DESCRIPTION
Currently the ingestion progress of an entire folder using the command line script can be quite annoying should errors happen.
Additionally, there is little feedback of the current overall progress if there are many files to be ingested.

For this reason this commit adds two things:

* Wrapping individual documents into a `try except` block
* Improve logging
    * Count total documents and show the current document count
    * Optionally log to a file
 
Using the following command as an example:

```bash
poetry run python ./scripts/ingest_folder.py ./tests --log-file ./test.log
```

The new console output can be seen here:

![image](https://github.com/imartinez/privateGPT/assets/18115780/72136969-1a52-4ca8-9e3b-c0054c81f49e)

With the following log file being created:

![image](https://github.com/imartinez/privateGPT/assets/18115780/edde2d60-80ce-44b6-89a0-f7228e0580ad)