### PR TITLE
Update README.md - fix grammatrical errors in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The API is divided into two logical blocks:
 **High-level API**, which abstracts all the complexity of a RAG (Retrieval Augmented Generation)
 pipeline implementation:
 - Ingestion of documents: internally managing document parsing,
-splitting, metadata extraction, embedding generation and storage.
+splitting, metadata extraction, embedding generation, and storage.
 - Chat & Completions using context from ingested documents:
-abstracting the retrieval of context, the prompt engineering and the response generation.
+abstracting the retrieval of context, the prompt engineering, and the response generation.
 
 **Low-level API**, which allows advanced users to implement their own complex pipelines:
 - Embeddings generation: based on a piece of text.


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**High level API**"

"**embedding generation and storage.**"  should be "**embedding generation, and storage.**"

" **engineering and the response generation.**"  should be " **engineering, and the response generation.**"

Screenshot-

![Screenshot (135)](https://github.com/imartinez/privateGPT/assets/115995339/dab07647-62e1-4579-ae55-e1dc9c2bd1f5)

