### PR TITLE
Disable Gradio Analytics

### DIFF
--- a/private_gpt/__init__.py
+++ b/private_gpt/__init__.py
@@ -1,11 +1,23 @@
 """private-gpt."""
 import logging
+import os
 
 # Set to 'DEBUG' to have extensive logging turned on, even for libraries
-ROOT_LOG_LEVEL = "INFO"
+ROOT_LOG_LEVEL = "DEBUG"
 
 PRETTY_LOG_FORMAT = (
     "%(asctime)s.%(msecs)03d [%(levelname)-8s] %(name)+25s - %(message)s"
 )
 logging.basicConfig(level=ROOT_LOG_LEVEL, format=PRETTY_LOG_FORMAT, datefmt="%H:%M:%S")
 logging.captureWarnings(True)
+
+# Disable gradio analytics
+# This is done this way because gradio does not solely rely on what values are
+# passed to gr.Blocks(enable_analytics=...) but also on the environment
+# variable GRADIO_ANALYTICS_ENABLED. `gradio.strings` actually reads this env
+# directly, so to fully disable gradio analytics we need to set this env var.
+os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
+
+# Disable chromaDB telemetry
+# It is already disabled, see PR#1144
+# os.environ["ANONYMIZED_TELEMETRY"] = "False"

--- a/private_gpt/__init__.py
+++ b/private_gpt/__init__.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 # Set to 'DEBUG' to have extensive logging turned on, even for libraries
-ROOT_LOG_LEVEL = "DEBUG"
+ROOT_LOG_LEVEL = "INFO"
 
 PRETTY_LOG_FORMAT = (
     "%(asctime)s.%(msecs)03d [%(levelname)-8s] %(name)+25s - %(message)s"

--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -111,7 +111,7 @@ with gr.Blocks(
     "}"
     ".logo img { height: 25% }",
 ) as blocks:
-    with gr.Blocks(), gr.Row():
+    with gr.Row():
         gr.HTML(f"<div class='logo'/><img src={logo_svg} alt=PrivateGPT></div")
 
     with gr.Row():


### PR DESCRIPTION
Gradio analytics can be disabled by either using the kwargs `enable_analytics` on `gr.Blocks`, or by setting the env variable `GRADIO_ANALYTICS_ENABLED` to something different from `True`.

Since that Gradio does not seem to respect their code contract (around `enable_analytics`), and that they are performing other operations only based on the value of `GRADIO_ANALYTICS_ENABLED` (c.f. `gradio.strings` https://github.com/gradio-app/gradio/blob/main/gradio/strings.py#L39), we are disabling gradio analytics by setting the required env variable to `False`.

Note: Setting an environment variables using `os.environ['foo'] = 'bar'` on system that are not based on unix might not work.

c.f. https://docs.python.org/3/library/os.html#os.environ for details on how `os.environ` works and all its caveats

See https://github.com/imartinez/privateGPT/pull/1144 for the similar PR on chromaDB telemetry (that motivated this PR)