### PR TITLE
Stake issues/PRs not update in 15 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 15
         stale-issue-message: 'Stale issue'
         stale-pr-message: 'Stale pull request'
         stale-issue-label: 'stale'


### PR DESCRIPTION
Moving temporarily to 15 days given all PRs and Issues were "updated" on Oct 19 to label them as "primordial"