### PR TITLE
Fix openai setting literal

### DIFF
--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -81,7 +81,7 @@ class DataSettings(BaseModel):
 
 
 class LLMSettings(BaseModel):
-    mode: Literal["local", "open_ai", "sagemaker", "mock"]
+    mode: Literal["local", "openai", "sagemaker", "mock"]
 
 
 class LocalSettings(BaseModel):


### PR DESCRIPTION
We had set it wrong in the Settings Literal, making it impossible to run on openai mode