### PR TITLE
feat: enable resume download for hf_hub_download

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 import os
+import argparse
 
 from huggingface_hub import hf_hub_download, snapshot_download
 
 from private_gpt.paths import models_path, models_cache_path
 from private_gpt.settings.settings import settings
+
+resume_download = True
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog='Setup: Download models from huggingface')
+    parser.add_argument('--resume', default=True, action=argparse.BooleanOptionalAction, help='Enable/Disable resume_download options to restart the download progress interrupted')
+    args = parser.parse_args()
+    resume_download = args.resume
 
 os.makedirs(models_path, exist_ok=True)
 embedding_path = models_path / "embedding"
@@ -24,6 +32,7 @@ hf_hub_download(
     filename=settings().local.llm_hf_model_file,
     cache_dir=models_cache_path,
     local_dir=models_path,
+    resume_download=resume_download,
 )
 
 print("LLM model downloaded!")


### PR DESCRIPTION
enable auto resume download by default to prevent always restart on downloading large file with poor network connection.