### PR TITLE
docs: Rearrange vectorstores section

### DIFF
--- a/docs/description.md
+++ b/docs/description.md
@@ -248,35 +248,6 @@ llama_new_context_with_model: total VRAM used: 4857.93 MB (model: 4095.05 MB, co
 AVX = 1 | AVX2 = 1 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 1 | SSSE3 = 0 | VSX = 0 | 
 ```
 
-#### Vectorstores
-PrivateGPT supports [Chroma](https://www.trychroma.com/), [Qdrant](https://qdrant.tech/) as vectorstore providers. Chroma being the default.
-
-To enable Qdrant, set the `vectorstore.database` property in the `settings.yaml` file to `qdrant` and install the `qdrant` extra.
-
-```bash
-poetry install --extras qdrant
-```
-
-By default Qdrant tries to connect to an instance at `http://localhost:3000`.
-
-Qdrant settings can be configured by setting values to the `qdrant` property in the `settings.yaml` file.
-
-The available configuration options are:
-| Field        | Description |
-|--------------|-------------|
-| location     | If `:memory:` - use in-memory Qdrant instance.<br>If `str` - use it as a `url` parameter.|
-| url          | Either host or str of 'Optional[scheme], host, Optional[port], Optional[prefix]'.<br> Eg. `http://localhost:6333` |
-| port         | Port of the REST API interface. Default: `6333` |
-| grpc_port    | Port of the gRPC interface. Default: `6334` |
-| prefer_grpc  | If `true` - use gRPC interface whenever possible in custom methods. |
-| https        | If `true` - use HTTPS(SSL) protocol.|
-| api_key      | API key for authentication in Qdrant Cloud.|
-| prefix       | If set, add `prefix` to the REST URL path.<br>Example: `service/v1` will result in `http://localhost:6333/service/v1/{qdrant-endpoint}` for REST API.|
-| timeout      | Timeout for REST and gRPC API requests.<br>Default: 5.0 seconds for REST and unlimited for gRPC |
-| host         | Host name of Qdrant service. If url and host are not set, defaults to 'localhost'.|
-| path         | Persistence path for QdrantLocal. Eg. `local_data/private_gpt/qdrant`|
-| force_disable_check_same_thread         | Force disable check_same_thread for QdrantLocal sqlite connection.|
-
 #### Known issues and Troubleshooting
 
 Execution of LLMs locally still has a lot of sharp edges, specially when running on non Linux platforms.
@@ -316,6 +287,35 @@ When running a Mac with Intel hardware (not M1), you may run into _clang: error:
 -march=native'_ during pip install.
 
 If so set your archflags during pip install. eg: _ARCHFLAGS="-arch x86_64" pip3 install -r requirements.txt_
+
+## Vectorstores
+PrivateGPT supports [Chroma](https://www.trychroma.com/), [Qdrant](https://qdrant.tech/) as vectorstore providers. Chroma being the default.
+
+To enable Qdrant, set the `vectorstore.database` property in the `settings.yaml` file to `qdrant` and install the `qdrant` extra.
+
+```bash
+poetry install --extras qdrant
+```
+
+By default Qdrant tries to connect to an instance at `http://localhost:3000`.
+
+Qdrant settings can be configured by setting values to the `qdrant` property in the `settings.yaml` file.
+
+The available configuration options are:
+| Field        | Description |
+|--------------|-------------|
+| location     | If `:memory:` - use in-memory Qdrant instance.<br>If `str` - use it as a `url` parameter.|
+| url          | Either host or str of 'Optional[scheme], host, Optional[port], Optional[prefix]'.<br> Eg. `http://localhost:6333` |
+| port         | Port of the REST API interface. Default: `6333` |
+| grpc_port    | Port of the gRPC interface. Default: `6334` |
+| prefer_grpc  | If `true` - use gRPC interface whenever possible in custom methods. |
+| https        | If `true` - use HTTPS(SSL) protocol.|
+| api_key      | API key for authentication in Qdrant Cloud.|
+| prefix       | If set, add `prefix` to the REST URL path.<br>Example: `service/v1` will result in `http://localhost:6333/service/v1/{qdrant-endpoint}` for REST API.|
+| timeout      | Timeout for REST and gRPC API requests.<br>Default: 5.0 seconds for REST and unlimited for gRPC |
+| host         | Host name of Qdrant service. If url and host are not set, defaults to 'localhost'.|
+| path         | Persistence path for QdrantLocal. Eg. `local_data/private_gpt/qdrant`|
+| force_disable_check_same_thread         | Force disable check_same_thread for QdrantLocal sqlite connection.|
 
 ## Running the Server
 


### PR DESCRIPTION
Move the vectorstore section in the docs to a distinct spot and use heading H2(##) for the title for hyperlinking purposes.