### PR TITLE
Add badges in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # 🔒 PrivateGPT 📑
 
+![Tests](https://github.com/imartinez/privateGPT/actions/workflows/tests.yml/badge.svg)
+![Website](https://img.shields.io/website?up_message=check%20it&down_message=down&url=https%3A%2F%2Fdocs.privategpt.dev%2F&label=Documentation)
+
+![Discord](https://img.shields.io/discord/1164200432894234644?logo=discord&label=PrivateGPT)
+![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/PrivateGPT_AI)
+
+
 > Install & usage docs: https://docs.privategpt.dev/
 > 
 > Join the community: [Twitter](https://twitter.com/PrivateGPT_AI) & [Discord](https://discord.gg/bK6mRVpErU)


### PR DESCRIPTION
Using https://shields.io/, and the github action badges: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge

To have the complete list of badges available, c.f. to their documentation: https://shields.io/badges

----
Attached, the result of the badges (to effective reviewing - they will be split in two lines: test and doc, and socials)

@imartinez still need to configure the Discord server to remove that "widget disabled" (using the video/tutorial there: https://shields.io/badges/discord)

![Tests](https://github.com/imartinez/privateGPT/actions/workflows/tests.yml/badge.svg)
![Website](https://img.shields.io/website?up_message=check%20it&down_message=down&url=https%3A%2F%2Fdocs.privategpt.dev%2F&label=Documentation)

![Discord](https://img.shields.io/discord/1164200432894234644?logo=discord&label=PrivateGPT)
![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/PrivateGPT_AI)