### PR TITLE
🌿 introduce `x-fern-streaming` extension

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "privategpt",
-  "version": "0.15.0-rc80"
+  "version": "0.15.0-rc88"
 }

--- a/fern/openapi/openapi.json
+++ b/fern/openapi/openapi.json
@@ -35,6 +35,15 @@
             },
             "required": true
           },
+          "x-fern-streaming": {
+            "stream-condition": "$request.stream",
+            "response": {
+              "$ref": "#/components/schemas/OpenAICompletion"
+            },
+            "response-stream": {
+              "$ref": "#/components/schemas/OpenAICompletion"
+            }
+          },
           "responses": {
             "200": {
               "description": "Successful Response",
@@ -76,6 +85,15 @@
               }
             },
             "required": true
+          },
+          "x-fern-streaming": {
+            "stream-condition": "$request.stream",
+            "response": {
+              "$ref": "#/components/schemas/OpenAICompletion"
+            },
+            "response-stream": {
+              "$ref": "#/components/schemas/OpenAICompletion"
+            }
           },
           "responses": {
             "200": {


### PR DESCRIPTION
In the `x-fern-streaming` extension you can specify a streaming version and non-streaming version of an endpoint. See the [docs](https://docs.buildwithfern.com/api-definition/open-api-specification/openapi/extensions#streaming)