### PR TITLE
fix: Windows permission error on ingest service tmp files

### DIFF
--- a/private_gpt/server/ingest/ingest_service.py
+++ b/private_gpt/server/ingest/ingest_service.py
@@ -121,6 +121,7 @@ class IngestService:
                             path_to_tmp.write_text(str(file_data))
                         documents = reader.load_data(path_to_tmp)
                     finally:
+                        tmp.close()
                         path_to_tmp.unlink()
         logger.info(
             "Transformed file=%s into count=%s documents", file_name, len(documents)


### PR DESCRIPTION
The ingestion API causes some permission troubles over the temporal files on Windows. A fix was recently added here #1260 but the unlinking causes a different trouble. On big files another `PermissionError` is throw because the file still being used by another process.
```
  File "E:\PycharmProjects\privateGPT\private_gpt\server\ingest\ingest_service.py", line 124, in ingest
    path_to_tmp.unlink()
  File "C:\Users\frang\.pyenv\pyenv-win\versions\3.11.0\Lib\pathlib.py", line 1147, in unlink
    os.unlink(self)
    PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\frang\\AppData\\Local\\Temp\\tmp4v0e9vnh'
```
Still being a permission error and It dont happen with small files. But closing the file before unlinking the path fix it for both cases on Windows 10. This might fix #1227 