### PR TITLE
Update ingest api docs with Windows support

### DIFF
--- a/fern/docs/pages/manual/ingestion.mdx
+++ b/fern/docs/pages/manual/ingestion.mdx
@@ -22,6 +22,13 @@ To log the processed and failed files to an additional file, use:
 make ingest /path/to/folder -- --watch --log-file /path/to/log/file.log
 ```
 
+**Note for Windows Users:** Depending on your Windows version and whether you are using PowerShell to execute
+PrivateGPT API calls, you may need to include the parameter name before passing the folder path for consumption:
+
+```bash
+make ingest arg=/path/to/folder -- --watch --log-file /path/to/log/file.log
+```
+
 After ingestion is complete, you should be able to chat with your documents
 by navigating to http://localhost:8001 and using the option `Query documents`,
 or using the completions / chat API.


### PR DESCRIPTION
Simple PR adding a note for parametrized `make` calls on Windows. 
Saw that some users were having some troubles making use of it on Windows command line here: #1226 (probably u can close this issue!)

If you prefer a different format to include this note on the docs just let me know and will modify it.
Thanks