### PR TITLE
Support local embedding with OpenAI chat

### DIFF
--- a/private_gpt/components/embedding/embedding_component.py
+++ b/private_gpt/components/embedding/embedding_component.py
@@ -21,7 +21,6 @@ class EmbeddingComponent:
                     cache_folder=str(models_cache_path),
                 )
             case "sagemaker":
-
                 from private_gpt.components.embedding.custom.sagemaker import (
                     SagemakerEmbedding,
                 )
@@ -38,3 +37,10 @@ class EmbeddingComponent:
                 # Not a random number, is the dimensionality used by
                 # the default embedding model
                 self.embedding_model = MockEmbedding(384)
+            case "hybrid":
+                from llama_index.embeddings import HuggingFaceEmbedding
+
+                self.embedding_model = HuggingFaceEmbedding(
+                    model_name=settings.local.embedding_hf_model_name,
+                    cache_folder=str(models_cache_path),
+                )

--- a/private_gpt/components/llm/llm_component.py
+++ b/private_gpt/components/llm/llm_component.py
@@ -45,3 +45,8 @@ class LLMComponent:
                 self.llm = OpenAI(api_key=openai_settings)
             case "mock":
                 self.llm = MockLLM()
+            case "hybrid":
+                from llama_index.llms import OpenAI
+
+                openai_settings = settings.openai.api_key
+                self.llm = OpenAI(api_key=openai_settings)

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -81,7 +81,7 @@ class DataSettings(BaseModel):
 
 
 class LLMSettings(BaseModel):
-    mode: Literal["local", "openai", "sagemaker", "mock"]
+    mode: Literal["local", "openai", "sagemaker", "mock", "hybrid"]
 
 
 class VectorstoreSettings(BaseModel):


### PR DESCRIPTION
Users can now locally embed documents and still choose to call out to OpenAI for chat completions.

Simply launching with the following settings.yaml

```yaml
llm:
  mode: hybrid
```

I understand using OpenAI is counter to the private aspect of privateGPT, but since OpenAI is supported already I found this useful for myself.

Also solves #1294 