### PR TITLE
Zephyr prompt style

### DIFF
--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -98,13 +98,14 @@ class LocalSettings(BaseModel):
     embedding_hf_model_name: str = Field(
         description="Name of the HuggingFace model to use for embeddings"
     )
-    prompt_style: Literal["default", "llama2", "tag"] = Field(
+    prompt_style: Literal["default", "llama2", "tag", "zephyr"] = Field(
         "llama2",
         description=(
             "The prompt style to use for the chat engine. "
             "If `default` - use the default prompt style from the llama_index. It should look like `role: message`.\n"
             "If `llama2` - use the llama2 prompt style from the llama_index. Based on `<s>`, `[INST]` and `<<SYS>>`.\n"
             "If `tag` - use the `tag` prompt style. It should look like `<|role|>: message`. \n"
+            "If `zephyr` - use the `zephyr` prompt style. It should look like `<|role|>\nmessage</s>`. It is similar to `tag` \n"
             "`llama2` is the historic behaviour. `default` might work better with your custom models."
         ),
     )


### PR DESCRIPTION
Coming from the example: https://github.com/run-llama/llama-hub/blob/7e5e3b1f74015ab0fc10eae2f903362bf57f3946/llama_hub/llama_packs/zephyr_query_engine/base.py#L37

Please note that you **may have to** remove to system prompt to fit to the example above