### PR TITLE
ci: fix preview docs checkout ref

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup Node.js 
         uses: actions/setup-node@v4


### PR DESCRIPTION
As of now, the preview workflow is doing the checkout on the ref provided for `pull_request_target` events, which points to the `main` branch.
That means that the changes in the PR will not actually be displayed in the preview, making it kind of useless.

This should fix the issue: it keeps the `pull_reuqest_target` event, so that the workflow can't be modified by the PR, but the checkout ref for building the docs will point to the PR ✨ 