### PR TITLE
docs: remove misleading comment about pgpt working with python 3.12

### DIFF
--- a/fern/docs/pages/installation/installation.mdx
+++ b/fern/docs/pages/installation/installation.mdx
@@ -10,7 +10,7 @@
 ```
 
 * Install Python `3.11` (*if you do not have it already*). Ideally through a python version manager like `pyenv`.
-  Python 3.12 should work too. Earlier python versions are not supported.
+  Earlier python versions are not supported.
     * osx/linux: [pyenv](https://github.com/pyenv/pyenv)
     * windows: [pyenv-win](https://github.com/pyenv-win/pyenv-win)
 


### PR DESCRIPTION
I was misled into believing I could install using python 3.12 whereas the pyproject.toml explicitly states otherwise. This PR only removes this comment to make sure other people are not also trapped 😄