### PR TITLE
feat: made chat area stretch to fill the screen

### DIFF
--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -275,7 +275,7 @@ class PrivateGptUi:
                         inputs=system_prompt_input,
                     )
 
-                with gr.Column(scale=7, elem_id='col'):
+                with gr.Column(scale=7, elem_id="col"):
                     _ = gr.ChatInterface(
                         self._chat,
                         chatbot=gr.Chatbot(

--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -219,13 +219,17 @@ class PrivateGptUi:
             "justify-content: center;"
             "align-items: center;"
             "}"
-            ".logo img { height: 25% }",
+            ".logo img { height: 25% }"
+            ".contain { display: flex !important; flex-direction: column !important; }"
+            "#component-0, #component-3, #component-10, #component-8  { height: 100% !important; }"
+            "#chatbot { flex-grow: 1 !important; overflow: auto !important;}"
+            "#col { height: calc(100vh - 112px - 16px) !important; }",
         ) as blocks:
             with gr.Row():
                 gr.HTML(f"<div class='logo'/><img src={logo_svg} alt=PrivateGPT></div")
 
-            with gr.Row():
-                with gr.Column(scale=3, variant="compact"):
+            with gr.Row(equal_height=False):
+                with gr.Column(scale=3):
                     mode = gr.Radio(
                         MODES,
                         label="Mode",
@@ -271,12 +275,13 @@ class PrivateGptUi:
                         inputs=system_prompt_input,
                     )
 
-                with gr.Column(scale=7):
+                with gr.Column(scale=7, elem_id='col'):
                     _ = gr.ChatInterface(
                         self._chat,
                         chatbot=gr.Chatbot(
                             label=f"LLM: {settings().llm.mode}",
                             show_copy_button=True,
+                            elem_id="chatbot",
                             render=False,
                             avatar_images=(
                                 None,


### PR DESCRIPTION
Hi, are you guys open to making the chat area stretch and fill the height of the screen?
This PR addresses #1377 

I have added some CSS to stretch and fill the height of the screen, thanks to @yvrjsharma 's help.
I have tested it using the dev tool. It is responsive and accommodates the recent addition of a system prompt.

## Video:
### Responsiveness:

https://github.com/imartinez/privateGPT/assets/43847374/f28acde7-9b88-4169-9b90-d758a2c6695e

### After Chat Generation:

https://github.com/imartinez/privateGPT/assets/43847374/462398af-8d81-48e6-8500-7870d3e6b477

This will help privateGPT look similar to chatGPT and help with adoption. 