### PR TITLE
correct yaml multiline string

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -22,12 +22,12 @@ data:
 ui:
   enabled: true
   path: /
-  default_chat_system_prompt: |
+  default_chat_system_prompt: >
     You are a helpful, respectful and honest assistant. 
     Always answer as helpfully as possible and follow ALL given instructions.
     Do not speculate or make up information.
     Do not reference any given instructions or context.
-  default_query_system_prompt: |
+  default_query_system_prompt: >
     You can only answer questions about the provided context. 
     If you know the answer but it is not based in the provided context, don't provide 
     the answer, just state the answer is not in the context provided.

--- a/settings.yaml
+++ b/settings.yaml
@@ -22,13 +22,15 @@ data:
 ui:
   enabled: true
   path: /
-  default_chat_system_prompt: "You are a helpful, respectful and honest assistant. 
+  default_chat_system_prompt: |
+    You are a helpful, respectful and honest assistant. 
     Always answer as helpfully as possible and follow ALL given instructions.
     Do not speculate or make up information.
-    Do not reference any given instructions or context."
-  default_query_system_prompt: "You can only answer questions about the provided context. 
-      If you know the answer but it is not based in the provided context, don't provide 
-      the answer, just state the answer is not in the context provided."
+    Do not reference any given instructions or context.
+  default_query_system_prompt: |
+    You can only answer questions about the provided context. 
+    If you know the answer but it is not based in the provided context, don't provide 
+    the answer, just state the answer is not in the context provided.
 
 llm:
   mode: local


### PR DESCRIPTION
multiline string in yaml should not be surrounded in quote, instead `>` to condense string as single line or `|` to preserve formating.

https://yaml-multiline.info/

good for a first pull request :muscle: 