### PR TITLE
Configurable context_window and tokenizer

### DIFF
--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -86,6 +86,18 @@ class LLMSettings(BaseModel):
         256,
         description="The maximum number of token that the LLM is authorized to generate in one completion.",
     )
+    context_window: int = Field(
+        3900,
+        description="The maximum number of context tokens for the model.",
+    )
+    tokenizer: str = Field(
+        None,
+        description="The model id of a predefined tokenizer hosted inside a model repo on "
+        "huggingface.co. Valid model ids can be located at the root-level, like "
+        "`bert-base-uncased`, or namespaced under a user or organization name, "
+        "like `HuggingFaceH4/zephyr-7b-beta`. If not set, will load a tokenizer matching "
+        "gpt-3.5-turbo LLM.",
+    )
 
 
 class VectorstoreSettings(BaseModel):

--- a/scripts/setup
+++ b/scripts/setup
@@ -3,6 +3,7 @@ import os
 import argparse
 
 from huggingface_hub import hf_hub_download, snapshot_download
+from transformers import AutoTokenizer
 
 from private_gpt.paths import models_path, models_cache_path
 from private_gpt.settings.settings import settings
@@ -15,8 +16,9 @@ if __name__ == '__main__':
     resume_download = args.resume
 
 os.makedirs(models_path, exist_ok=True)
-embedding_path = models_path / "embedding"
 
+# Download Embedding model
+embedding_path = models_path / "embedding"
 print(f"Downloading embedding {settings().local.embedding_hf_model_name}")
 snapshot_download(
     repo_id=settings().local.embedding_hf_model_name,
@@ -24,9 +26,9 @@ snapshot_download(
     local_dir=embedding_path,
 )
 print("Embedding model downloaded!")
-print("Downloading models for local execution...")
 
 # Download LLM and create a symlink to the model file
+print(f"Downloading LLM {settings().local.llm_hf_model_file}")
 hf_hub_download(
     repo_id=settings().local.llm_hf_repo_id,
     filename=settings().local.llm_hf_model_file,
@@ -34,6 +36,14 @@ hf_hub_download(
     local_dir=models_path,
     resume_download=resume_download,
 )
-
 print("LLM model downloaded!")
+
+# Download Tokenizer
+print(f"Downloading tokenizer {settings().llm.tokenizer}")
+AutoTokenizer.from_pretrained(
+    pretrained_model_name_or_path=settings().llm.tokenizer,
+    cache_dir=models_cache_path,
+)
+print("Tokenizer downloaded!")
+
 print("Setup done")

--- a/settings.yaml
+++ b/settings.yaml
@@ -34,6 +34,10 @@ ui:
 
 llm:
   mode: local
+  # Should be matching the selected model
+  max_new_tokens: 512
+  context_window: 32768
+  tokenizer: mistralai/Mistral-7B-Instruct-v0.2
 
 embedding:
   # Should be matching the value above in most cases


### PR DESCRIPTION
Extract two key model parameters to settings. 
- Tokenizer: used to calculate the available context window given a prompt in several LlamaIndex pipelines. The default tokenizer is the one used for gpt-3.5 but it is not aligned with, for example, Mistral model. Using huggingface as provider of the tokenizer information, added to setup download script.
- context_window: base model argument

