### PR TITLE
Fixing minor bug in chat stream output - python error being serialized

### DIFF
--- a/private_gpt/open_ai/openai_models.py
+++ b/private_gpt/open_ai/openai_models.py
@@ -118,5 +118,5 @@ def to_openai_sse_stream(
             yield f"data: {OpenAICompletion.json_from_delta(text=response.delta)}\n\n"
         else:
             yield f"data: {OpenAICompletion.json_from_delta(text=response, sources=sources)}\n\n"
-    yield f"data: {OpenAICompletion.json_from_delta(text=None, finish_reason='stop')}\n\n"
+    yield f"data: {OpenAICompletion.json_from_delta(text='', finish_reason='stop')}\n\n"
     yield "data: [DONE]\n\n"


### PR DESCRIPTION
This is a proposed fix for a minor bug I noticed while using [simonw/llm](https://github.com/simonw/llm) to connect to a local privategpt instance -- I'm seeing serialized python error strings in the output. I'm not entirely sure why this shows up in this tool, but not via the UI, but it might have to do with how the output is parsed or something.

Behavior I was seeing:

```llm -m l2-8001 -s "You can only answer questions about the provided context. If you know the answer but it is not based in the provided context, don't provide the answer, just state the answer is not in the context provided." 'what are containers'
Containers, in the context of computing and software development, are lightweight, standalone, executable software packages that include everything needed to run a piece of software: code, runtime, system tools, system libraries, and 

<... snip additional output...>

Containers have become a key component in modern software development and deployment practices, particularly in the context of microservices architectures, where applications are built as a collection of loosely coupled services.Error: can only concatenate str (not "NoneType") to str
```

The `Error: can only concatenate str (not "NoneType") to str` seems to be coming from the server-side. There might be a better way to fix this, but this seemed to work (and aligns w/ my expectations of a fix for `NoneType` being concatenated w/ `str`).