### PR TITLE
Check for our own test module, given some libs load unittest by default

### DIFF
--- a/private_gpt/settings/settings_loader.py
+++ b/private_gpt/settings/settings_loader.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 _settings_folder = os.environ.get("PGPT_SETTINGS_FOLDER", PROJECT_ROOT_PATH)
 
 # if running in unittest, use the test profile
-_test_profile = ["test"] if "unittest" in sys.modules else []
+_test_profile = ["test"] if "tests.fixtures" in sys.modules else []
 
 active_profiles: list[str] = unique_list(
     ["default"]


### PR DESCRIPTION
Previous implementation causes false positives with the last version of LlamaIndex, making PGPT load settings-test.yaml when being launched. That breaks the UI and other functionalities.