### PR TITLE
Fix: Adding an LLM param to fix generator producing only "#####" characters

### DIFF
--- a/private_gpt/components/llm/llm_component.py
+++ b/private_gpt/components/llm/llm_component.py
@@ -42,7 +42,7 @@ class LLMComponent:
                     context_window=settings.llm.context_window,
                     generate_kwargs={},
                     # All to GPU
-                    model_kwargs={"n_gpu_layers": -1},
+                    model_kwargs={"n_gpu_layers": -1, "offload_kqv": True},
                     # transform inputs into Llama2 format
                     messages_to_prompt=prompt_style.messages_to_prompt,
                     completion_to_prompt=prompt_style.completion_to_prompt,


### PR DESCRIPTION
The newer versions of `llama-cpp-python` do not have the parameter `offload_kqv` set to True. Fixing this in privateGPT is pretty straightforward. Instead of installing a lower version of `llama-cpp-python`, adding `"offload_kqv": True` to `model_kwargs` enables KGV offloading, and also significantly boosts GPU performance. 