### PR TITLE
GUI _upload_file

### DIFF
--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -203,6 +203,21 @@ class PrivateGptUi:
     def _upload_file(self, files: list[str]) -> None:
         logger.debug("Loading count=%s files", len(files))
         paths = [Path(file) for file in files]
+
+        # remove all existing Documents with name identical to a new file upload:
+        file_names = [path.name for path in paths]
+        doc_ids_to_delete = []
+        for ingested_document in self._ingest_service.list_ingested():
+            if ingested_document.doc_metadata["file_name"] in file_names:
+                doc_ids_to_delete.append(ingested_document.doc_id)
+        if len(doc_ids_to_delete) > 0:
+            logger.info(
+                "Uploading file(s) which were already ingested: %s document(s) will be replaced.",
+                len(doc_ids_to_delete),
+            )
+            for doc_id in doc_ids_to_delete:
+                self._ingest_service.delete(doc_id)
+
         self._ingest_service.bulk_ingest([(str(path.name), path) for path in paths])
 
     def _build_ui_blocks(self) -> gr.Blocks:


### PR DESCRIPTION
GUI _upload_file: remove all existing Documents with name identical to a new file upload

Ingesting the same file(name) again, causes new(er) Documents to be added, while old Documents remain present as is.
I adjusted the "Upload File(s)" button to avoid this unintuitive behaviour:

1. Delete existing Documents with the same filename
2. Ingest the file as normal

As mentioned in:
https://github.com/imartinez/privateGPT/pull/1493

