### PR TITLE
upgrade fern to 0.17.2 to fix broken docs pages (streaming endpoints)

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "privategpt",
-  "version": "0.15.3"
+  "version": "0.17.2"
 }


### PR DESCRIPTION
privateGPT is on an older version of Fern CLI, which doesn't fully support parsing streaming endpoints defined in OpenAPI, causing an outage on a few pages of the docs under `Contextual Completions`.

Upgrading the CLI and running `fern generate --docs` will fix it.