### PR TITLE
Maintain score order when curating sources

### DIFF
--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -44,8 +44,8 @@ class Source(BaseModel):
         frozen = True
 
     @staticmethod
-    def curate_sources(sources: list[Chunk]) -> set["Source"]:
-        curated_sources = set()
+    def curate_sources(sources: list[Chunk]) -> list["Source"]:
+        curated_sources = []
 
         for chunk in sources:
             doc_metadata = chunk.document.doc_metadata
@@ -54,8 +54,10 @@ class Source(BaseModel):
             page_label = doc_metadata.get("page_label", "-") if doc_metadata else "-"
 
             source = Source(file=file_name, page=page_label, text=chunk.text)
-            curated_sources.add(source)
+            curated_sources.append(source)
 
+        curated_sources = list(dict.fromkeys(curated_sources).keys()) # Unique sources only
+        
         return curated_sources
 
 

--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -55,9 +55,10 @@ class Source(BaseModel):
 
             source = Source(file=file_name, page=page_label, text=chunk.text)
             curated_sources.append(source)
+            curated_sources = list(
+                dict.fromkeys(curated_sources).keys()
+            )  # Unique sources only
 
-        curated_sources = list(dict.fromkeys(curated_sources).keys()) # Unique sources only
-        
         return curated_sources
 
 


### PR DESCRIPTION
I noticed that every time after restarting PrivateGPT, the output on the screen would vary with similar queries used in "Search Files" mode even though the retrieved 'response' contained the same values that were ordered to the same scores.

After some troubleshooting, it looked like the output from the Source.curate_sources(response) function mixes up the values, which results in sources that are no longer ordered to the reponse scores.

In order to fix this, 'curated_sources' in the 'Source' class is changed from a set to a unique list to ensure that the score order is maintained and the results are consistent. 