### PR TITLE
Check for duplicates in sources before outputting to the chat

### DIFF
--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -102,7 +102,6 @@ class PrivateGptUi:
                     if source.file not in used_files:
                         sources_text = sources_text +f"{index}. {source.file} (page {source.page}) \n\n"
                         used_files.add(source.file + "-" + source.page)
-                        logger.info(urllib.parse.unquote(source.file))
                 full_response += sources_text
             yield full_response
 

--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -99,7 +99,7 @@ class PrivateGptUi:
                 sources_text = "\n\n\n"
                 used_files = set()
                 for index, source in enumerate(cur_sources, start=1):
-                    if source.file not in used_files:
+                    if (source.file+"-"+source.page) not in used_files:
                         sources_text = sources_text +f"{index}. {source.file} (page {source.page}) \n\n"
                         used_files.add(source.file + "-" + source.page)
                 full_response += sources_text

--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -96,10 +96,13 @@ class PrivateGptUi:
             if completion_gen.sources:
                 full_response += SOURCES_SEPARATOR
                 cur_sources = Source.curate_sources(completion_gen.sources)
-                sources_text = "\n\n\n".join(
-                    f"{index}. {source.file} (page {source.page})"
-                    for index, source in enumerate(cur_sources, start=1)
-                )
+                sources_text = "\n\n\n"
+                used_files = set()
+                for index, source in enumerate(cur_sources, start=1):
+                    if source.file not in used_files:
+                        sources_text = sources_text +f"{index}. {source.file} (page {source.page}) \n\n"
+                        used_files.add(source.file + "-" + source.page)
+                        logger.info(urllib.parse.unquote(source.file))
                 full_response += sources_text
             yield full_response
 


### PR DESCRIPTION
I found that after increasing
similarity_top_k: int  in vector_store_component.py to something higher, like 10, I would getting some duplicate hits in the sources used.  

Instead of just outputting the sources, as you loop through these, inject them into an array.  If the item already exists in the array, dont readd this to the sources_text.