### PR TITLE
Updated prompt_style to be included under the LLM setting and not jus…

### DIFF
--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -104,6 +104,17 @@ class LLMSettings(BaseModel):
         0.1,
         description="The temperature of the model. Increasing the temperature will make the model answer more creatively. A value of 0.1 would be more factual.",
     )
+    prompt_style: Literal["default", "llama2", "tag", "mistral", "chatml"] = Field(
+        "llama2",
+        description=(
+            "The prompt style to use for the chat engine. "
+            "If `default` - use the default prompt style from the llama_index. It should look like `role: message`.\n"
+            "If `llama2` - use the llama2 prompt style from the llama_index. Based on `<s>`, `[INST]` and `<<SYS>>`.\n"
+            "If `tag` - use the `tag` prompt style. It should look like `<|role|>: message`. \n"
+            "If `mistral` - use the `mistral prompt style. It shoudl look like <s>[INST] {System Prompt} [/INST]</s>[INST] { UserInstructions } [/INST]"
+            "`llama2` is the historic behaviour. `default` might work better with your custom models."
+        ),
+    )
 
 
 class VectorstoreSettings(BaseModel):

--- a/settings.yaml
+++ b/settings.yaml
@@ -35,6 +35,7 @@ ui:
   delete_all_files_button_enabled: true
 
 llm:
+  prompt_style: "mistral"
   mode: llamacpp
   # Should be matching the selected model
   max_new_tokens: 512


### PR DESCRIPTION
prompt_style was only under LlamaCPP. I have implemented this with openailike, though I think all of the llamaindex intergrations can use it.  I have placed prompt_style under llm, which can easily be added to others after testing.

I also included the token limit and temperature settings for openailike as well.