### PR TITLE
Display ingested file paths instead of file names

### DIFF
--- a/private_gpt/components/ingest/ingest_helper.py
+++ b/private_gpt/components/ingest/ingest_helper.py
@@ -73,7 +73,7 @@ class IngestionHelper:
     ) -> list[Document]:
         documents = IngestionHelper._load_file_to_documents(file_name, file_data)
         for document in documents:
-            document.metadata["file_name"] = file_name
+            document.metadata["file_name"] = str(file_data)
         IngestionHelper._exclude_metadata(documents)
         return documents
 

--- a/private_gpt/components/ingest/ingest_helper.py
+++ b/private_gpt/components/ingest/ingest_helper.py
@@ -79,7 +79,7 @@ class IngestionHelper:
 
     @staticmethod
     def _load_file_to_documents(file_name: str, file_data: Path) -> list[Document]:
-        logger.debug("Transforming file_name=%s into documents", file_name)
+        logger.debug("Transforming file=%s into documents", str(file_data))
         extension = Path(file_name).suffix
         reader_cls = FILE_READER_CLS.get(extension)
         if reader_cls is None:

--- a/private_gpt/ui/ui.py
+++ b/private_gpt/ui/ui.py
@@ -334,7 +334,7 @@ class PrivateGptUi:
                     )
                     ingested_dataset = gr.List(
                         self._list_ingested_files,
-                        headers=["File name"],
+                        headers=["Files"],
                         label="Ingested Files",
                         height=235,
                         interactive=False,


### PR DESCRIPTION
## Description

The current implementation only displays the ingested filenames, which can be confusing for users when the specified directory for ingestion contains nested directories with multiple levels. Additionally, the existing implementation discards files with different names e.g. a root_path directory contains index.md, dir1/index.md, dir2/index.md, only one single `index.md` file is displayed. This PR enhances the display by including the file paths instead of just filenames, addressing the potential confusion caused by nested directories, and ensures that all files are appropriately displayed without discarding any.

## Fix preview

![Screenshot from 2024-04-03 10-10-22](https://github.com/zylon-ai/private-gpt/assets/7053612/5545aa2a-1d2b-4973-b1ca-5ff4b46d96f5)
