### PR TITLE
Make embedding_api_base match api_base when on docker

### DIFF
--- a/settings-docker.yaml
+++ b/settings-docker.yaml
@@ -23,6 +23,7 @@ ollama:
   llm_model: ${PGPT_OLLAMA_LLM_MODEL:mistral}
   embedding_model: ${PGPT_OLLAMA_EMBEDDING_MODEL:nomic-embed-text}
   api_base: ${PGPT_OLLAMA_API_BASE:http://ollama:11434}
+  embedding_api_base: ${PGPT_OLLAMA_EMBEDDING_API_BASE:http://ollama:11434}
   tfs_z: ${PGPT_OLLAMA_TFS_Z:1.0}
   top_k: ${PGPT_OLLAMA_TOP_K:40}
   top_p: ${PGPT_OLLAMA_TOP_P:0.9}


### PR DESCRIPTION
When docker-compose the embedding URL should point to `http://ollama:11434` rather than `http://localhost:11434`.