### PR TITLE
feat: Add metadata to ingestion routes

### DIFF
--- a/private_gpt/components/ingest/ingest_component.py
+++ b/private_gpt/components/ingest/ingest_component.py
@@ -44,7 +44,7 @@ class BaseIngestComponent(abc.ABC):
         self,
         file_name: str,
         file_data: Path,
-        file_metadata: dict[str, str] | None = None,
+        file_metadata: dict[str, Any] | None = None,
     ) -> list[Document]:
         pass
 
@@ -126,7 +126,7 @@ class SimpleIngestComponent(BaseIngestComponentWithIndex):
         self,
         file_name: str,
         file_data: Path,
-        file_metadata: dict[str, str] | None = None,
+        file_metadata: dict[str, Any] | None = None,
     ) -> list[Document]:
         logger.info("Ingesting file_name=%s", file_name)
         documents = IngestionHelper.transform_file_into_documents(
@@ -191,7 +191,7 @@ class BatchIngestComponent(BaseIngestComponentWithIndex):
         self,
         file_name: str,
         file_data: Path,
-        file_metadata: dict[str, str] | None = None,
+        file_metadata: dict[str, Any] | None = None,
     ) -> list[Document]:
         logger.info("Ingesting file_name=%s", file_name)
         documents = IngestionHelper.transform_file_into_documents(
@@ -281,7 +281,7 @@ class ParallelizedIngestComponent(BaseIngestComponentWithIndex):
         self,
         file_name: str,
         file_data: Path,
-        file_metadata: dict[str, str] | None = None,
+        file_metadata: dict[str, Any] | None = None,
     ) -> list[Document]:
         logger.info("Ingesting file_name=%s", file_name)
         # Running in a single (1) process to release the current
@@ -489,7 +489,7 @@ class PipelineIngestComponent(BaseIngestComponentWithIndex):
         self,
         file_name: str,
         file_data: Path,
-        file_metadata: dict[str, str] | None = None,
+        file_metadata: dict[str, Any] | None = None,
     ) -> list[Document]:
         documents = IngestionHelper.transform_file_into_documents(
             file_name, file_data, file_metadata

--- a/private_gpt/components/ingest/ingest_helper.py
+++ b/private_gpt/components/ingest/ingest_helper.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Any
 
 from llama_index.core.readers import StringIterableReader
 from llama_index.core.readers.base import BaseReader
@@ -69,7 +70,7 @@ class IngestionHelper:
 
     @staticmethod
     def transform_file_into_documents(
-        file_name: str, file_data: Path, file_metadata: dict[str, str] | None = None
+        file_name: str, file_data: Path, file_metadata: dict[str, Any] | None = None
     ) -> list[Document]:
         documents = IngestionHelper._load_file_to_documents(file_name, file_data)
         for document in documents:

--- a/private_gpt/components/ingest/ingest_helper.py
+++ b/private_gpt/components/ingest/ingest_helper.py
@@ -69,13 +69,13 @@ class IngestionHelper:
 
     @staticmethod
     def transform_file_into_documents(
-        file_name: str, file_data: Path, file_metadata : dict | None = None
+        file_name: str, file_data: Path, file_metadata: dict[str, str] | None = None
     ) -> list[Document]:
         documents = IngestionHelper._load_file_to_documents(file_name, file_data)
         for document in documents:
             document.metadata.update(file_metadata or {})
             document.metadata["file_name"] = file_name
-            
+
         IngestionHelper._exclude_metadata(documents)
         return documents
 

--- a/private_gpt/components/ingest/ingest_helper.py
+++ b/private_gpt/components/ingest/ingest_helper.py
@@ -69,11 +69,13 @@ class IngestionHelper:
 
     @staticmethod
     def transform_file_into_documents(
-        file_name: str, file_data: Path
+        file_name: str, file_data: Path, file_metadata : dict | None = None
     ) -> list[Document]:
         documents = IngestionHelper._load_file_to_documents(file_name, file_data)
         for document in documents:
+            document.metadata.update(file_metadata or {})
             document.metadata["file_name"] = file_name
+            
         IngestionHelper._exclude_metadata(documents)
         return documents
 

--- a/private_gpt/server/ingest/ingest_router.py
+++ b/private_gpt/server/ingest/ingest_router.py
@@ -49,6 +49,10 @@ def ingest(request: Request, file: UploadFile) -> IngestResponse:
 @ingest_router.post("/ingest/file", tags=["Ingestion"])
 def ingest_file(request: Request, file: UploadFile, metadata: str = Form(None)) -> IngestResponse:
     """Ingests and processes a file, storing its chunks to be used as context.
+    
+    metadata: Optional metadata to be associated with the file. 
+    You do not have to specify this field if not needed.
+    e.g. {"title": "Avatar: The Last Airbender", "author": "Michael Dante DiMartino, Bryan Konietzko", "year": "2005"}
 
     The context obtained from files is later used in
     `/chat/completions`, `/completions`, and `/chunks` APIs.
@@ -84,6 +88,7 @@ def ingest_text(request: Request, body: IngestTextBody) -> IngestResponse:
     extracted Metadata (which is later used to improve context retrieval). That ID
     can be used to filter the context used to create responses in
     `/chat/completions`, `/completions`, and `/chunks` APIs.
+
     """
     service = request.state.injector.get(IngestService)
     if len(body.file_name) == 0:

--- a/private_gpt/server/ingest/ingest_router.py
+++ b/private_gpt/server/ingest/ingest_router.py
@@ -1,4 +1,5 @@
-from typing import Literal
+import json
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, UploadFile
 from pydantic import BaseModel, Field
@@ -20,7 +21,7 @@ class IngestTextBody(BaseModel):
             "Chinese martial arts."
         ]
     )
-    metadata: dict[str, str] = Field(
+    metadata: dict[str, Any] = Field(
         None,
         examples=[
             {
@@ -55,6 +56,7 @@ def ingest_file(
 
     metadata: Optional metadata to be associated with the file.
     You do not have to specify this field if not needed.
+    The metadata needs to be in JSON format.
     e.g. {"title": "Avatar: The Last Airbender", "year": "2005"}
 
     The context obtained from files is later used in
@@ -74,7 +76,7 @@ def ingest_file(
     if file.filename is None:
         raise HTTPException(400, "No file name provided")
 
-    metadata_dict = None if metadata is None else eval(metadata)
+    metadata_dict = None if metadata is None else json.loads(metadata)
     ingested_documents = service.ingest_bin_data(
         file.filename, file.file, metadata_dict
     )

--- a/private_gpt/server/ingest/ingest_service.py
+++ b/private_gpt/server/ingest/ingest_service.py
@@ -48,7 +48,12 @@ class IngestService:
             settings=settings(),
         )
 
-    def _ingest_data(self, file_name: str, file_data: AnyStr, file_metadata : dict | None = None) -> list[IngestedDoc]:
+    def _ingest_data(
+        self,
+        file_name: str,
+        file_data: AnyStr,
+        file_metadata: dict[str, str] | None = None,
+    ) -> list[IngestedDoc]:
         logger.debug("Got file data of size=%s to ingest", len(file_data))
         # llama-index mainly supports reading from files, so
         # we have to create a tmp file to read for it to work
@@ -65,18 +70,28 @@ class IngestService:
                 tmp.close()
                 path_to_tmp.unlink()
 
-    def ingest_file(self, file_name: str, file_data: Path, file_metadata : dict | None = None) -> list[IngestedDoc]:
+    def ingest_file(
+        self,
+        file_name: str,
+        file_data: Path,
+        file_metadata: dict[str, str] | None = None,
+    ) -> list[IngestedDoc]:
         logger.info("Ingesting file_name=%s", file_name)
         documents = self.ingest_component.ingest(file_name, file_data, file_metadata)
         logger.info("Finished ingestion file_name=%s", file_name)
         return [IngestedDoc.from_document(document) for document in documents]
 
-    def ingest_text(self, file_name: str, text: str, metadata : dict | None = None) -> list[IngestedDoc]:
+    def ingest_text(
+        self, file_name: str, text: str, metadata: dict[str, str] | None = None
+    ) -> list[IngestedDoc]:
         logger.debug("Ingesting text data with file_name=%s", file_name)
         return self._ingest_data(file_name, text, metadata)
 
     def ingest_bin_data(
-        self, file_name: str, raw_file_data: BinaryIO, file_metadata : dict | None = None
+        self,
+        file_name: str,
+        raw_file_data: BinaryIO,
+        file_metadata: dict[str, str] | None = None,
     ) -> list[IngestedDoc]:
         logger.debug("Ingesting binary data with file_name=%s", file_name)
         file_data = raw_file_data.read()

--- a/private_gpt/server/ingest/ingest_service.py
+++ b/private_gpt/server/ingest/ingest_service.py
@@ -48,7 +48,7 @@ class IngestService:
             settings=settings(),
         )
 
-    def _ingest_data(self, file_name: str, file_data: AnyStr) -> list[IngestedDoc]:
+    def _ingest_data(self, file_name: str, file_data: AnyStr, file_metadata : dict | None = None) -> list[IngestedDoc]:
         logger.debug("Got file data of size=%s to ingest", len(file_data))
         # llama-index mainly supports reading from files, so
         # we have to create a tmp file to read for it to work
@@ -60,27 +60,27 @@ class IngestService:
                     path_to_tmp.write_bytes(file_data)
                 else:
                     path_to_tmp.write_text(str(file_data))
-                return self.ingest_file(file_name, path_to_tmp)
+                return self.ingest_file(file_name, path_to_tmp, file_metadata)
             finally:
                 tmp.close()
                 path_to_tmp.unlink()
 
-    def ingest_file(self, file_name: str, file_data: Path) -> list[IngestedDoc]:
+    def ingest_file(self, file_name: str, file_data: Path, file_metadata : dict | None = None) -> list[IngestedDoc]:
         logger.info("Ingesting file_name=%s", file_name)
-        documents = self.ingest_component.ingest(file_name, file_data)
+        documents = self.ingest_component.ingest(file_name, file_data, file_metadata)
         logger.info("Finished ingestion file_name=%s", file_name)
         return [IngestedDoc.from_document(document) for document in documents]
 
-    def ingest_text(self, file_name: str, text: str) -> list[IngestedDoc]:
+    def ingest_text(self, file_name: str, text: str, metadata : dict | None = None) -> list[IngestedDoc]:
         logger.debug("Ingesting text data with file_name=%s", file_name)
-        return self._ingest_data(file_name, text)
+        return self._ingest_data(file_name, text, metadata)
 
     def ingest_bin_data(
-        self, file_name: str, raw_file_data: BinaryIO
+        self, file_name: str, raw_file_data: BinaryIO, file_metadata : dict | None = None
     ) -> list[IngestedDoc]:
         logger.debug("Ingesting binary data with file_name=%s", file_name)
         file_data = raw_file_data.read()
-        return self._ingest_data(file_name, file_data)
+        return self._ingest_data(file_name, file_data, file_metadata)
 
     def bulk_ingest(self, files: list[tuple[str, Path]]) -> list[IngestedDoc]:
         logger.info("Ingesting file_names=%s", [f[0] for f in files])

--- a/tests/fixtures/ingest_helper.py
+++ b/tests/fixtures/ingest_helper.py
@@ -1,7 +1,7 @@
+import json
 from pathlib import Path
 
 import pytest
-import json
 from fastapi.testclient import TestClient
 
 from private_gpt.server.ingest.ingest_router import IngestResponse
@@ -18,15 +18,15 @@ class IngestHelper:
         assert response.status_code == 200
         ingest_result = IngestResponse.model_validate(response.json())
         return ingest_result
-    
+
     def ingest_file_with_metadata(self, path: Path, metadata: dict) -> IngestResponse:
         files = {
             "file": (path.name, path.open("rb")),
-            "metadata": (None, json.dumps(metadata))
+            "metadata": (None, json.dumps(metadata)),
         }
 
         response = self.test_client.post("/v1/ingest/file", files=files)
-        
+
         assert response.status_code == 200
         ingest_result = IngestResponse.model_validate(response.json())
         return ingest_result

--- a/tests/fixtures/ingest_helper.py
+++ b/tests/fixtures/ingest_helper.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import json
 from fastapi.testclient import TestClient
 
 from private_gpt.server.ingest.ingest_router import IngestResponse
@@ -14,6 +15,18 @@ class IngestHelper:
         files = {"file": (path.name, path.open("rb"))}
 
         response = self.test_client.post("/v1/ingest/file", files=files)
+        assert response.status_code == 200
+        ingest_result = IngestResponse.model_validate(response.json())
+        return ingest_result
+    
+    def ingest_file_with_metadata(self, path: Path, metadata: dict) -> IngestResponse:
+        files = {
+            "file": (path.name, path.open("rb")),
+            "metadata": (None, json.dumps(metadata))
+        }
+
+        response = self.test_client.post("/v1/ingest/file", files=files)
+        
         assert response.status_code == 200
         ingest_result = IngestResponse.model_validate(response.json())
         return ingest_result

--- a/tests/fixtures/ingest_helper.py
+++ b/tests/fixtures/ingest_helper.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -19,7 +20,9 @@ class IngestHelper:
         ingest_result = IngestResponse.model_validate(response.json())
         return ingest_result
 
-    def ingest_file_with_metadata(self, path: Path, metadata: dict) -> IngestResponse:
+    def ingest_file_with_metadata(
+        self, path: Path, metadata: dict[str, Any]
+    ) -> IngestResponse:
         files = {
             "file": (path.name, path.open("rb")),
             "metadata": (None, json.dumps(metadata)),

--- a/tests/server/ingest/test_ingest_routes.py
+++ b/tests/server/ingest/test_ingest_routes.py
@@ -48,16 +48,20 @@ def test_ingest_plain_text(test_client: TestClient) -> None:
 
 def test_ingest_text_with_metadata(test_client: TestClient):
     response = test_client.post(
-        "/v1/ingest/text", json={"file_name": "file_name", "text": "text", "metadata": {"foo": "bar"}}
+        "/v1/ingest/text",
+        json={"file_name": "file_name", "text": "text", "metadata": {"foo": "bar"}},
     )
     assert response.status_code == 200
     ingest_result = IngestResponse.model_validate(response.json())
     assert len(ingest_result.data) == 1
-   
-    assert ingest_result.data[0].doc_metadata == {"file_name" : "file_name", "foo": "bar"}
+
+    assert ingest_result.data[0].doc_metadata == {
+        "file_name": "file_name",
+        "foo": "bar",
+    }
 
 
-def test_ingest_accepts_txt_files(ingest_helper: IngestHelper) -> None:
+def test_ingest_accepts_txt_files_with_metadata(ingest_helper: IngestHelper) -> None:
     path = Path(__file__).parents[0] / "test.txt"
     ingest_result = ingest_helper.ingest_file_with_metadata(path, {"foo": "bar"})
     assert len(ingest_result.data) == 1

--- a/tests/server/ingest/test_ingest_routes.py
+++ b/tests/server/ingest/test_ingest_routes.py
@@ -44,3 +44,21 @@ def test_ingest_plain_text(test_client: TestClient) -> None:
     assert response.status_code == 200
     ingest_result = IngestResponse.model_validate(response.json())
     assert len(ingest_result.data) == 1
+
+
+def test_ingest_text_with_metadata(test_client: TestClient):
+    response = test_client.post(
+        "/v1/ingest/text", json={"file_name": "file_name", "text": "text", "metadata": {"foo": "bar"}}
+    )
+    assert response.status_code == 200
+    ingest_result = IngestResponse.model_validate(response.json())
+    assert len(ingest_result.data) == 1
+   
+    assert ingest_result.data[0].doc_metadata == {"file_name" : "file_name", "foo": "bar"}
+
+
+def test_ingest_accepts_txt_files(ingest_helper: IngestHelper) -> None:
+    path = Path(__file__).parents[0] / "test.txt"
+    ingest_result = ingest_helper.ingest_file_with_metadata(path, {"foo": "bar"})
+    assert len(ingest_result.data) == 1
+    assert ingest_result.data[0].doc_metadata == {"file_name": "test.txt", "foo": "bar"}


### PR DESCRIPTION
# Description

This PR adds the ability to specify additional metadata in text and file ingestion routes.

This feature might be useful for people creating custom UIs with PrivateGPT and that want to add additional informations to the document sources, or for people using a custom ingestion pipeline with readers that may use the metadata. This feature could also be extended to bulk ingestion, but this would be a good start.

This is an important part of the project, so I wanted to make sure nothing breaks. 
I added two unit tests, one for the text ingestion route and one for the file ingestion route.
I also tested all of the ingestion modes to make sure nothing breaks. 

## Type of Change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

**Test Configuration**:
* Firmware version: 0.5

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make check; make test` to ensure mypy and tests pass