### PR TITLE
Do not override TIKTOKEN_CACHE_DIR if the user has set it

### DIFF
--- a/private_gpt/__init__.py
+++ b/private_gpt/__init__.py
@@ -24,4 +24,5 @@ os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 # os.environ["ANONYMIZED_TELEMETRY"] = "False"
 
 # adding tiktoken cache path within repo to be able to run in offline environment.
-os.environ["TIKTOKEN_CACHE_DIR"] = "tiktoken_cache"
+# Only set to cache within the repo if the user has not declared a cache path
+os.environ.setdefault("TIKTOKEN_CACHE_DIR", "tiktoken_cache")


### PR DESCRIPTION
# Description

This is a minor MR to change the `TIKTOKEN_CACHE_DIR` ENV var override from a hard override, to a set-if-unset default.  This allows users to tune TIKTOKEN_CACHE_DIR, which is handy if the user wants the cache outside the repo.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [X] I stared at the code and made sure it makes sense
- [X] I tested a local instance without `TIKTOKEN_CACHE_DIR` set and ensured it wrote a file into `tiktoken_cache`
- [X] I tested a local instance with `TIKTOKEN_CACHE_DIR` set and ensured it wrote a file into the specified directory

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I ran `make check; make test` to ensure mypy and tests pass