### PR TITLE
Remove deprecated tfs_z parameter for Ollama compatibility

### DIFF
--- a/private_gpt/components/llm/llm_component.py
+++ b/private_gpt/components/llm/llm_component.py
@@ -53,7 +53,7 @@ class LLMComponent:
 
                 prompt_style = get_prompt_style(settings.llm.prompt_style)
                 settings_kwargs = {
-                    "tfs_z": settings.llamacpp.tfs_z,  # ollama and llama-cpp
+                    "tfs_z": settings.llamacpp.tfs_z,  # llama-cpp only
                     "top_k": settings.llamacpp.top_k,  # ollama and llama-cpp
                     "top_p": settings.llamacpp.top_p,  # ollama and llama-cpp
                     "repeat_penalty": settings.llamacpp.repeat_penalty,  # ollama llama-cpp
@@ -137,7 +137,6 @@ class LLMComponent:
                 ollama_settings = settings.ollama
 
                 settings_kwargs = {
-                    "tfs_z": ollama_settings.tfs_z,  # ollama and llama-cpp
                     "num_predict": ollama_settings.num_predict,  # ollama only
                     "top_k": ollama_settings.top_k,  # ollama and llama-cpp
                     "top_p": ollama_settings.top_p,  # ollama and llama-cpp

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -301,10 +301,6 @@ class OllamaSettings(BaseModel):
         "5m",
         description="Time the model will stay loaded in memory after a request. examples: 5m, 5h, '-1' ",
     )
-    tfs_z: float = Field(
-        1.0,
-        description="Tail free sampling is used to reduce the impact of less probable tokens from the output. A higher value (e.g., 2.0) will reduce the impact more, while a value of 1.0 disables this setting.",
-    )
     num_predict: int = Field(
         None,
         description="Maximum number of tokens to predict when generating text. (Default: 128, -1 = infinite generation, -2 = fill context)",

--- a/settings-docker.yaml
+++ b/settings-docker.yaml
@@ -24,7 +24,6 @@ ollama:
   embedding_model: ${PGPT_OLLAMA_EMBEDDING_MODEL:nomic-embed-text}
   api_base: ${PGPT_OLLAMA_API_BASE:http://ollama:11434}
   embedding_api_base: ${PGPT_OLLAMA_EMBEDDING_API_BASE:http://ollama:11434}
-  tfs_z: ${PGPT_OLLAMA_TFS_Z:1.0}
   top_k: ${PGPT_OLLAMA_TOP_K:40}
   top_p: ${PGPT_OLLAMA_TOP_P:0.9}
   repeat_last_n: ${PGPT_OLLAMA_REPEAT_LAST_N:64}

--- a/settings-ollama.yaml
+++ b/settings-ollama.yaml
@@ -16,7 +16,6 @@ ollama:
   api_base: http://localhost:11434
   embedding_api_base: http://localhost:11434  # change if your embedding model runs on another ollama
   keep_alive: 5m
-  tfs_z: 1.0              # Tail free sampling is used to reduce the impact of less probable tokens from the output. A higher value (e.g., 2.0) will reduce the impact more, while a value of 1.0 disables this setting.
   top_k: 40               # Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative. (Default: 40)
   top_p: 0.9              # Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. (Default: 0.9)
   repeat_last_n: 64       # Sets how far back for the model to look back to prevent repetition. (Default: 64, 0 = disabled, -1 = num_ctx)


### PR DESCRIPTION
Fixes #2143

Ollama 0.5.7+ removed the `tfs_z` sampling parameter. Sending it causes `invalid option provided` warnings on every request and can break setups that treat warnings as errors.

This removes `tfs_z` from the Ollama settings model, the Ollama kwargs dict in `llm_component.py`, and the Ollama sections of the YAML config files. The parameter is kept for the llamacpp backend, which still supports it.