### PR TITLE
Feat: Add openGauss DataVec vector store component

### DIFF
--- a/fern/docs/pages/manual/vectordb.mdx
+++ b/fern/docs/pages/manual/vectordb.mdx
@@ -1,7 +1,7 @@
 ## Vectorstores
-PrivateGPT supports [Qdrant](https://qdrant.tech/), [Milvus](https://milvus.io/), [Chroma](https://www.trychroma.com/), [PGVector](https://github.com/pgvector/pgvector) and [ClickHouse](https://github.com/ClickHouse/ClickHouse) as vectorstore providers. Qdrant being the default.
+PrivateGPT supports [Qdrant](https://qdrant.tech/), [Milvus](https://milvus.io/), [Chroma](https://www.trychroma.com/), [PGVector](https://github.com/pgvector/pgvector), [openGauss](https://opengauss.org/) and [ClickHouse](https://github.com/ClickHouse/ClickHouse) as vectorstore providers. Qdrant being the default.
 
-In order to select one or the other, set the `vectorstore.database` property in the `settings.yaml` file to `qdrant`, `milvus`, `chroma`, `postgres` and `clickhouse`.
+In order to select one or the other, set the `vectorstore.database` property in the `settings.yaml` file to `qdrant`, `milvus`, `chroma`, `postgres`, `openGauss` or `clickhouse`.
 
 ```yaml
 vectorstore:
@@ -119,6 +119,36 @@ Indexes:
 postgres=# 
 ```
 The dimensions of the embeddings columns will be set based on the `embedding.embed_dim` value.  If the embedding model changes this table may need to be dropped and recreated to avoid a dimension mismatch.
+
+### openGauss
+
+To use the openGauss vector store an [openGauss](https://opengauss.org/) database is required. DataVec (pgvector-compatible) is built
+into the openGauss kernel — no extension installation is needed.
+
+To enable openGauss, set the `vectorstore.database` property in the `settings.yaml` file to `openGauss` and install the `vector-stores-postgres` extra.
+
+```bash
+poetry install --extras vector-stores-postgres
+```
+
+openGauss settings can be configured by setting values to the `openGauss` property in the `settings.yaml` file.
+
+The available configuration options are:
+| Field                         | Description                                               |
+|-------------------------------|-----------------------------------------------------------|
+| **connection_string**         | Full SQLAlchemy connection string. Example: `postgresql+psycopg2://user:pass@host:port/db`. If the password contains special characters (e.g. `@`), they must be URL-encoded (`%40`). |
+| **async_connection_string**   | Async connection string. Defaults to `connection_string` with the driver replaced (`+psycopg2://` → `+asyncpg://`). |
+| **schema_name**               | The database schema to use. Default is `private_gpt`.     |
+
+For example:
+```yaml
+vectorstore:
+  database: openGauss
+
+openGauss:
+  connection_string: "postgresql+psycopg2://gaussdb:password@localhost:5432/postgres"
+  schema_name: private_gpt
+```
 
 ### ClickHouse
 

--- a/private_gpt/components/vector_store/vector_store_component.py
+++ b/private_gpt/components/vector_store/vector_store_component.py
@@ -14,7 +14,53 @@ from private_gpt.open_ai.extensions.context_filter import ContextFilter
 from private_gpt.paths import local_data_path
 from private_gpt.settings.settings import Settings
 
+try:
+    from llama_index.vector_stores.postgres import (  # type: ignore
+        PGVectorStore,
+    )
+except ImportError:
+
+    class PGVectorStore:  # type: ignore[no-redef]
+        """Placeholder when pgvector extras are not installed."""
+
+
 logger = logging.getLogger(__name__)
+
+
+class OpenGaussVectorStore(PGVectorStore):  # type: ignore[misc]
+    """PGVectorStore subclass for openGauss databases.
+
+    openGauss differences from standard PostgreSQL:
+
+    1. ``SELECT version()`` returns ``(openGauss-lite 7.0.0-RC1...)``
+       instead of ``(PostgreSQL 15.0...)``, which causes SQLAlchemy's
+       dialect to throw ``AssertionError``.  The fallback returns a safe
+       default version on each engine's dialect *instance* — no global
+       side effects.
+    2. DataVec (pgvector) is built into the openGauss kernel, so
+       ``CREATE EXTENSION`` is not needed.
+    """
+
+    def _create_extension(self) -> None:
+        """Skip — DataVec is built into the openGauss kernel."""
+        pass
+
+    def _connect(self) -> typing.Any:
+        super()._connect()
+        self._patch_dialect_version(self._engine)
+        self._patch_dialect_version(self._async_engine)
+
+    @staticmethod
+    def _patch_dialect_version(engine: typing.Any) -> None:
+        original = engine.dialect._get_server_version_info
+
+        def _patched_get_version(connection: typing.Any) -> tuple[int, int]:
+            try:
+                return typing.cast(tuple[int, int], original(connection))
+            except AssertionError:
+                return (12, 0)
+
+        engine.dialect._get_server_version_info = _patched_get_version
 
 
 def _doc_id_metadata_filter(
@@ -57,6 +103,35 @@ class VectorStoreComponent:
                     BasePydanticVectorStore,
                     PGVectorStore.from_params(
                         **settings.postgres.model_dump(exclude_none=True),
+                        table_name="embeddings",
+                        embed_dim=settings.embedding.embed_dim,
+                    ),
+                )
+
+            case "openGauss":
+                try:
+                    from llama_index.vector_stores.postgres import (  # type: ignore
+                        PGVectorStore,
+                    )
+                except ImportError as e:
+                    raise ImportError(
+                        "Postgres dependencies not found, install with `poetry install --extras vector-stores-postgres`"
+                    ) from e
+
+                if settings.openGauss is None:
+                    raise ValueError(
+                        "openGauss settings not found. Please provide openGauss.connection_string."
+                    )
+
+                self.vector_store = typing.cast(
+                    BasePydanticVectorStore,
+                    OpenGaussVectorStore.from_params(
+                        connection_string=settings.openGauss.connection_string,
+                        async_connection_string=settings.openGauss.async_connection_string
+                        or settings.openGauss.connection_string.replace(
+                            "+psycopg2://", "+asyncpg://"
+                        ),
+                        schema_name=settings.openGauss.schema_name,
                         table_name="embeddings",
                         embed_dim=settings.embedding.embed_dim,
                     ),

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -153,7 +153,9 @@ class LLMSettings(BaseModel):
 
 
 class VectorstoreSettings(BaseModel):
-    database: Literal["chroma", "qdrant", "postgres", "clickhouse", "milvus"]
+    database: Literal[
+        "chroma", "qdrant", "postgres", "openGauss", "clickhouse", "milvus"
+    ]
 
 
 class NodeStoreSettings(BaseModel):
@@ -512,6 +514,25 @@ class PostgresSettings(BaseModel):
     )
 
 
+class OpenGaussSettings(BaseModel):
+    connection_string: str = Field(
+        ...,
+        description=(
+            "Full connection string for openGauss database. "
+            "When provided, bypasses host/port/user/password/database fields. "
+            "Example: postgresql+psycopg2://user:pass@host:port/db"
+        ),
+    )
+    async_connection_string: str | None = Field(
+        None,
+        description="Async connection string for openGauss. Defaults to connection_string if not set.",
+    )
+    schema_name: str = Field(
+        "private_gpt",
+        description="The name of the schema in the openGauss database to use",
+    )
+
+
 class QdrantSettings(BaseModel):
     location: str | None = Field(
         None,
@@ -606,6 +627,7 @@ class Settings(BaseModel):
     summarize: SummarizeSettings
     qdrant: QdrantSettings | None = None
     postgres: PostgresSettings | None = None
+    openGauss: OpenGaussSettings | None = None
     clickhouse: ClickHouseSettings | None = None
     milvus: MilvusSettings | None = None
 


### PR DESCRIPTION
# Description

Add openGauss database vector store support for PrivateGPT. openGauss has built-in DataVec (pgvector-compatible) in its kernel, which allows it to serve as a drop-in vector store backend via the existing PGVectorStore protocol.

Two key differences from standard PostgreSQL:

1. **Built-in DataVec** — `CREATE EXTENSION` is not needed since pgvector is integrated into the openGauss kernel. Override `_create_extension()` to skip it.
2. **Version detection** — `SELECT version()` returns `openGauss-lite 7.0.0-RC1...` instead of a standard PostgreSQL version string, causing SQLAlchemy's dialect to throw `AssertionError`. Monkey-patch the dialect instance's `_get_server_version_info` to fall back to a safe default, avoiding global side effects.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] I stared at the code and made sure it makes sense

**make check**:
- `black` — 1 file reformatted, 87 files unchanged
- `ruff` — All checks passed
- `mypy` — Success: no issues found in 65 source files

**make test**:
- 41 passed, 0 failed, 15 warnings (all from third-party dependency deprecations, not introduced by this PR)

**Test Configuration**:
* Firmware version: N/A
* Hardware: WSL2 (x86_64)
* Toolchain: Python 3.11.6, Poetry 2.4.1
* SDK: N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran `make check; make test` to ensure mypy and tests pass
