### PR TITLE
chore: add codespell support (config, workflow, pre-commit) and fix detected typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,8 @@ repos:
     language: system
     types: [python]
     stages: [push]
+- repo: https://github.com/codespell-project/codespell
+  # Configuration for codespell is in pyproject.toml
+  rev: v2.4.1
+  hooks:
+  - id: codespell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 * prompt_style applied to all LLMs + extra LLM params. ([#1835](https://github.com/zylon-ai/private-gpt/issues/1835)) ([e21bf20](https://github.com/zylon-ai/private-gpt/commit/e21bf20c10938b24711d9f2c765997f44d7e02a9))
 * **recipe:** add our first recipe  `Summarize` ([#2028](https://github.com/zylon-ai/private-gpt/issues/2028)) ([8119842](https://github.com/zylon-ai/private-gpt/commit/8119842ae6f1f5ecfaf42b06fa0d1ffec675def4))
 * **vectordb:** Milvus vector db Integration ([#1996](https://github.com/zylon-ai/private-gpt/issues/1996)) ([43cc31f](https://github.com/zylon-ai/private-gpt/commit/43cc31f74015f8d8fcbf7a8ea7d7d9ecc66cf8c9))
-* **vectorstore:** Add clickhouse support as vectore store ([#1883](https://github.com/zylon-ai/private-gpt/issues/1883)) ([2612928](https://github.com/zylon-ai/private-gpt/commit/26129288394c7483e6fc0496a11dc35679528cc1))
+* **vectorstore:** Add clickhouse support as vector store ([#1883](https://github.com/zylon-ai/private-gpt/issues/1883)) ([2612928](https://github.com/zylon-ai/private-gpt/commit/26129288394c7483e6fc0496a11dc35679528cc1))
 
 
 ### Bug Fixes
@@ -70,7 +70,7 @@
 * **docs:** upgrade fern ([#1596](https://github.com/zylon-ai/private-gpt/issues/1596)) ([84ad16a](https://github.com/zylon-ai/private-gpt/commit/84ad16af80191597a953248ce66e963180e8ddec))
 * **ingest:** Created a faster ingestion mode - pipeline ([#1750](https://github.com/zylon-ai/private-gpt/issues/1750)) ([134fc54](https://github.com/zylon-ai/private-gpt/commit/134fc54d7d636be91680dc531f5cbe2c5892ac56))
 * **llm - embed:** Add support for Azure OpenAI ([#1698](https://github.com/zylon-ai/private-gpt/issues/1698)) ([1efac6a](https://github.com/zylon-ai/private-gpt/commit/1efac6a3fe19e4d62325e2c2915cd84ea277f04f))
-* **llm:** adds serveral settings for llamacpp and ollama ([#1703](https://github.com/zylon-ai/private-gpt/issues/1703)) ([02dc83e](https://github.com/zylon-ai/private-gpt/commit/02dc83e8e9f7ada181ff813f25051bbdff7b7c6b))
+* **llm:** adds several settings for llamacpp and ollama ([#1703](https://github.com/zylon-ai/private-gpt/issues/1703)) ([02dc83e](https://github.com/zylon-ai/private-gpt/commit/02dc83e8e9f7ada181ff813f25051bbdff7b7c6b))
 * **llm:** Ollama LLM-Embeddings decouple + longer keep_alive settings ([#1800](https://github.com/zylon-ai/private-gpt/issues/1800)) ([b3b0140](https://github.com/zylon-ai/private-gpt/commit/b3b0140e244e7a313bfaf4ef10eb0f7e4192710e))
 * **llm:** Ollama timeout setting ([#1773](https://github.com/zylon-ai/private-gpt/issues/1773)) ([6f6c785](https://github.com/zylon-ai/private-gpt/commit/6f6c785dac2bbad37d0b67fda215784298514d39))
 * **local:** tiktoken cache within repo for offline ([#1467](https://github.com/zylon-ai/private-gpt/issues/1467)) ([821bca3](https://github.com/zylon-ai/private-gpt/commit/821bca32e9ee7c909fd6488445ff6a04463bf91b))

--- a/fern/docs/pages/installation/installation.mdx
+++ b/fern/docs/pages/installation/installation.mdx
@@ -274,7 +274,7 @@ You'll need to have a valid C++ compiler like gcc installed. See [Troubleshootin
 You will need to build [llama.cpp](https://github.com/ggerganov/llama.cpp) with metal support.
 
 To do that, you need to install `llama.cpp` python's binding `llama-cpp-python` through pip, with the compilation flag
-that activate `METAL`: you have to pass `-DLLAMA_METAL=on` to the CMake command tha `pip` runs for you (see below).
+that activate `METAL`: you have to pass `-DLLAMA_METAL=on` to the CMake command that `pip` runs for you (see below).
 
 In other words, one should simply run:
 ```bash

--- a/fern/docs/pages/manual/reranker.mdx
+++ b/fern/docs/pages/manual/reranker.mdx
@@ -4,7 +4,7 @@ PrivateGPT offers a reranking feature aimed at optimizing response generation by
 
 ### Enabling Reranking
 
-Document reranking can significantly improve the efficiency and quality of the responses by pre-selecting the most relevant documents before generating an answer. To leverage this feature, ensure that it is enabled in the RAG settings and consider adjusting the parameters to best fit your use case.
+Document reranking can significantly improve the efficiency and quality of the responses by preselecting the most relevant documents before generating an answer. To leverage this feature, ensure that it is enabled in the RAG settings and consider adjusting the parameters to best fit your use case.
 
 #### Additional Requirements
 

--- a/private_gpt/components/llm/custom/sagemaker.py
+++ b/private_gpt/components/llm/custom/sagemaker.py
@@ -62,7 +62,7 @@ class LineIterator:
     within the buffer via the 'scan_lines' function. It maintains the position of the
     last read position to ensure that previous bytes are not exposed again. It will
     also save any pending lines that doe not end with a '\n' to make sure truncations
-    are concatinated
+    are concatenated
     """
 
     def __init__(self, stream: Any) -> None:

--- a/private_gpt/settings/settings.py
+++ b/private_gpt/settings/settings.py
@@ -145,7 +145,7 @@ class LLMSettings(BaseModel):
                 "If `llama2` - use the llama2 prompt style from the llama_index. Based on `<s>`, `[INST]` and `<<SYS>>`.\n"
                 "If `llama3` - use the llama3 prompt style from the llama_index."
                 "If `tag` - use the `tag` prompt style. It should look like `<|role|>: message`. \n"
-                "If `mistral` - use the `mistral prompt style. It shoudl look like <s>[INST] {System Prompt} [/INST]</s>[INST] { UserInstructions } [/INST]"
+                "If `mistral` - use the `mistral prompt style. It should look like <s>[INST] {System Prompt} [/INST]</s>[INST] { UserInstructions } [/INST]"
                 "`llama2` is the historic behaviour. `default` might work better with your custom models."
             ),
         )
@@ -214,7 +214,7 @@ class EmbeddingSettings(BaseModel):
             "If `batch` - if multiple files, parse all the files in parallel, "
             "and send them in batch to the embedding model.\n"
             "In `pipeline` - The Embedding engine is kept as busy as possible\n"
-            "If `parallel` - parse the files in parallel using multiple cores, and embedd them in parallel.\n"
+            "If `parallel` - parse the files in parallel using multiple cores, and embed them in parallel.\n"
             "`parallel` is the fastest mode for local setup, as it parallelize IO RW in the index.\n"
             "For modes that leverage parallelization, you can specify the number of "
             "workers to use with `count_workers`.\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,3 +195,10 @@ testpaths = ["tests"]
 addopts = [
     "--import-mode=importlib",
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.pdf,*.lock'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -7,6 +7,6 @@ def test_settings_are_loaded_and_merged() -> None:
 
 
 def test_settings_can_be_overriden(injector: MockInjector) -> None:
-    injector.bind_settings({"server": {"env_name": "overriden"}})
+    injector.bind_settings({"server": {"env_name": "overridden"}})
     mocked_settings = injector.get(Settings)
-    assert mocked_settings.server.env_name == "overriden"
+    assert mocked_settings.server.env_name == "overridden"


### PR DESCRIPTION
# Description

Adds [codespell](https://github.com/codespell-project/codespell) spell-checking infrastructure to the project (config, CI workflow, pre-commit hook) and fixes the typos it found.

This re-submits the earlier #2191 (closed). The branch was rebased onto current `main` and the typo-fixing commit re-ran on the latest tree, picking up a newly-introduced typo (`pre-selecting` → `preselecting` in `fern/docs/pages/manual/reranker.mdx`) that wasn't present when #2191 was opened.

I have personally introduced codespell to over a hundred of projects already, mostly with positive feedback. The CI workflow has `permissions: contents: read` only, so it is safe.

More about codespell: https://github.com/codespell-project/codespell

## Commits

- e5de113 `Add github action to codespell main on push and PRs`
- 430bb20 `Add rudimentary codespell config`
- 2531f7f `Add pre-commit definition for codespell`
- b60a815 `[DATALAD RUNCMD] chore: run codespell throughout fixing a few typos interactively`
- 85b8abc `[DATALAD RUNCMD] chore: run codespell throughout fixing a few typos automagically`

<details><summary>What each commit does</summary>

### e5de113 `Add github action to codespell main on push and PRs`

Adds `.github/workflows/codespell.yml`. Runs on push to `main` and PRs targeting `main`. `permissions: contents: read` only.

### 430bb20 `Add rudimentary codespell config`

Adds `[tool.codespell]` section to `pyproject.toml` with a minimal skip list (`.git*,*.pdf,*.lock`) and `check-hidden = true`. `ignore-regex` and `ignore-words-list` are present commented out, ready to be extended if needed later.

### 2531f7f `Add pre-commit definition for codespell`

Adds codespell to `.pre-commit-config.yaml` (rev `v2.4.1`). Reuses the `[tool.codespell]` config from `pyproject.toml`.

### b60a815 `[DATALAD RUNCMD] chore: run codespell throughout fixing a few typos interactively`

One context-reviewed fix in `fern/docs/pages/installation/installation.mdx`: `tha` → `that`.

### 85b8abc `[DATALAD RUNCMD] chore: run codespell throughout fixing a few typos automagically`

Runs `codespell -w` to fix all remaining non-ambiguous typos:

- `vectore` → `vector` (CHANGELOG.md)
- `serveral` → `several` (CHANGELOG.md)
- `pre-selecting` → `preselecting` (fern/docs/pages/manual/reranker.mdx)
- `concatinated` → `concatenated` (private_gpt/components/llm/custom/sagemaker.py)
- `shoudl` → `should` (private_gpt/settings/settings.py)
- `embedd` → `embed` (private_gpt/settings/settings.py)
- `overriden` → `overridden` (tests/settings/test_settings.py — string values only; the surrounding function name `test_settings_can_be_overriden` is unchanged because codespell doesn't split identifiers on `_`, so test discovery / external references remain intact).

</details>

<details><summary>Historical context</summary>

`git log --grep=typo --grep=spell --grep=spelling` on `main` shows 8 prior commits manually fixing typos — automating this with codespell prevents the next round.

</details>

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) — typo fixes in docstrings, comments, CHANGELOG, and one test string. No runtime/behavioral changes.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update — handled inline (typos in `.mdx` docs are fixed in this PR).

## How Has This Been Tested?

- `uvx codespell` locally returns exit 0 (no errors) on the final tree.
- Diff was manually reviewed for false positives by AI and HI — none found. All fixes are in strings, comments, docstrings, or markdown prose; no identifiers were renamed.
- The one test string change (`tests/settings/test_settings.py`) only changes the value used in `bind_settings` and the matching `assert`, so the test's semantic remains "verify that an overridden value is read back".

- [ ] Added new unit/integration tests — n/a, typo PR.
- [x] I stared at the code and made sure it makes sense.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas — n/a.
- [x] I have made corresponding changes to the documentation — typos in `fern/docs/pages/**/*.mdx` are fixed.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, codespell CI is itself the regression guard.
- [x] New and existing unit tests pass locally with my changes — only typo strings were modified in tests.
- [x] Any dependent changes have been merged and published in downstream modules — n/a.

