### PR TITLE
fix: make embedding API key optional for local OpenAI-compatible engines

### DIFF
--- a/private_gpt/components/embedding/factories/openailike.py
+++ b/private_gpt/components/embedding/factories/openailike.py
@@ -27,7 +27,11 @@ class OpenAILikeEmbeddingFactory(EmbeddingFactory):
         api_base = (
             self.settings.openai.embedding_api_base or self.settings.openai.api_base
         )
-        api_key = self.settings.openai.embedding_api_key or self.settings.openai.api_key
+        api_key = (
+            self.settings.openai.embedding_api_key
+            or self.settings.openai.api_key
+            or "default"
+        )
         model = model_config.name
 
         embedding_model = OpenAILikeEmbedding(

--- a/tests/components/embedding/test_openai_embedding_factory.py
+++ b/tests/components/embedding/test_openai_embedding_factory.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch
+
+from private_gpt.components.embedding.factories.openai import OpenAIEmbeddingFactory
+from private_gpt.settings.settings import (
+    EmbeddingModelConfig,
+    Settings,
+    unsafe_settings,
+)
+
+
+def _settings(
+    *,
+    api_base: str,
+    api_key: str,
+    embedding_api_base: str | None,
+    embedding_api_key: str | None,
+) -> Settings:
+    settings = Settings(**unsafe_settings)
+    settings.openai.api_base = api_base
+    settings.openai.api_key = api_key
+    settings.openai.embedding_api_base = embedding_api_base
+    settings.openai.embedding_api_key = embedding_api_key
+    return settings
+
+
+def _config() -> EmbeddingModelConfig:
+    return EmbeddingModelConfig(
+        name="mxbai-embed-large", mode="openai", context_window=512
+    )
+
+
+def test_local_openai_compatible_engine_does_not_require_api_key() -> None:
+    # Regression test for #2260: a local engine (Ollama, vLLM, ...) must embed
+    # without an API key instead of failing with "Missing credentials".
+    settings = _settings(
+        api_base="http://localhost:11434/v1",
+        api_key="",
+        embedding_api_base="http://localhost:11434/v1",
+        embedding_api_key=None,
+    )
+
+    with patch(
+        "llama_index.embeddings.openai_like.OpenAILikeEmbedding"
+    ) as mock_embedding:
+        OpenAIEmbeddingFactory(settings)._create_embedding(_config())
+
+    _, kwargs = mock_embedding.call_args
+    assert kwargs["api_key"]
+
+
+def test_real_openai_endpoint_keeps_real_key() -> None:
+    # api.openai.com must keep the real (empty) key and fail loudly instead of
+    # silently receiving a placeholder key.
+    settings = _settings(
+        api_base="https://api.openai.com/v1",
+        api_key="",
+        embedding_api_base=None,
+        embedding_api_key=None,
+    )
+
+    with patch("llama_index.embeddings.openai.OpenAIEmbedding") as mock_embedding:
+        OpenAIEmbeddingFactory(settings)._create_embedding(_config())
+
+    _, kwargs = mock_embedding.call_args
+    assert kwargs["api_key"] == ""


### PR DESCRIPTION
## Summary

Ingesting documents with a local OpenAI-compatible embedding engine (Ollama, vLLM, ...) fails with:

```
openai.OpenAIError: Missing credentials. Please pass an `api_key` ... or set the `OPENAI_API_KEY` ... environment variable.
```

even though chat works fine against the same engine. This makes key-less local setups unusable for ingestion.

Fixes #2260.

## Root cause

The embedding model for a local engine is built by `OpenAILikeEmbeddingFactory`, which forwarded the resolved key straight to the client:

```python
api_key = self.settings.openai.embedding_api_key or self.settings.openai.api_key
```

When neither key is set (the normal case for Ollama), this is an empty string, and the underlying `openai.OpenAI` client rejects empty credentials — but only lazily, on the first real request. That is why:

- **startup succeeds** — constructing `OpenAILikeEmbedding` does not open the client;
- **model discovery succeeds** — the discovery probe already guards against this with `api_key or "no-key"` (`embedding/discovery.py`);
- **chat succeeds** — the chat factory already guards with `api_key or "default"` (`llm/factories/completions/openailike.py`);
- **ingestion is the first call that actually embeds**, so it is where the missing-credentials error surfaces.

In short, the OpenAI-like embedding factory was the only path missing the placeholder-key fallback that both chat and embedding discovery already use.

## Fix

Mirror the chat path: fall back to a placeholder key on the local OpenAI-compatible embedding path.

```python
api_key = (
    self.settings.openai.embedding_api_key
    or self.settings.openai.api_key
    or "default"
)
```

The strict `api.openai.com` path (`OpenAIGPTEmbeddingFactory`) is intentionally left unchanged — it should keep failing loudly on a genuinely missing key rather than send a fake one and get a confusing `401`.

## Before / after (workaround no longer needed)

Previously this only worked by setting dummy keys:

```bash
docker run -p 8080:8080 \
  -e OPENAI_API_BASE=https://<ollama>/v1 \
  -e OPENAI_EMBEDDING_API_BASE=https://<ollama>/v1 \
  -e OPENAI_API_KEY=ollama \
  -e OPENAI_EMBEDDING_API_KEY=ollama \
  zylonai/private-gpt:latest
```

With this change, the two `*_API_KEY` variables are no longer required for a local engine.

## Tests

Adds `tests/components/embedding/test_openai_embedding_factory.py`:

- `test_local_openai_compatible_engine_does_not_require_api_key` — local engine + no key now receives a non-empty key (fails before this change).
- `test_real_openai_endpoint_keeps_real_key` — guards that the strict OpenAI path is not given a placeholder key.

`pytest`, `ruff check`, `ruff format --check`, and `mypy` all pass on the changed files.
