### PR TITLE
perf(prompts): use date-level current_date to preserve prompt-prefix caching

### DIFF
--- a/private_gpt/components/prompts/prompt_builder.py
+++ b/private_gpt/components/prompts/prompt_builder.py
@@ -117,7 +117,12 @@ class PromptBuilderService:
             assistant_name=assistant_name or settings().chat.assistant_name,
             assistant_description=assistant_description
             or settings().chat.assistant_description,
-            current_date=current_date.astimezone().isoformat(),
+            # Use date-level granularity: a sub-second timestamp here changes on
+            # every request and sits at the front of the system prompt (before the
+            # guidelines and retrieved context), which defeats LLM prompt-prefix
+            # caching (e.g. OpenAI automatic prefix caching, local KV-cache reuse).
+            # The model only needs the calendar date for relative-date reasoning.
+            current_date=current_date.astimezone().date().isoformat(),
         )
 
     def create_chat_context_for_system_prompt(


### PR DESCRIPTION
### What
`create_chat_header_prompt` renders `current_date` with full `datetime.now().isoformat()` (sub-second precision) into the system prompt header, **before** the guidelines and retrieved-context blocks (`chat/system/base.j2`). Because this value changes on every request, the system-prompt prefix is never byte-stable.

### Why it matters
A volatile value at the front of the system prompt defeats LLM **prompt-prefix caching** for every backend that relies on a stable prefix:
- OpenAI **automatic prefix caching** (always on) — forfeits the cached-input discount;
- Anthropic `cache_control` (when callers pass the request-level `cache_control` this project already supports) — forces a cache write each turn;
- local llama.cpp / KV-cache prefix reuse.

For a RAG app that re-sends large retrieved context every turn, this is a recurring, silent cost/latency overhead (no error, output unchanged).

### Fix
Use date-level granularity (`.date().isoformat()` -> `2026-06-16`). The model only needs the calendar date for relative-date reasoning ("today"/"tomorrow"), and the prefix stays stable within a day. Minimal and behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)