### PR TITLE
docs: add SECURITY.md for private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the latest `main` branch and the most recent published releases. Please upgrade when possible.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+If you believe you have found a security vulnerability in PrivateGPT, report it privately so maintainers can investigate and remediate before public disclosure.
+
+### Preferred channels
+
+1. **GitHub Private Vulnerability Reporting** (when enabled on this repository): use the **Security** tab → **Report a vulnerability**.
+2. **Discord**: join the [PrivateGPT Discord](https://discord.gg/F8KCFeZbkx) and ask a maintainer for a private channel — do not paste exploit details in public channels.
+3. **X / social**: [@ZylonPrivateGPT](https://twitter.com/ZylonPrivateGPT) can be used only to request a private contact path, not to share technical details.
+
+Please include:
+
+- A description of the issue and its impact
+- Steps to reproduce (or a proof of concept)
+- Affected component(s), versions, and environment details
+- Any suggested remediation if known
+
+### What to expect
+
+- We will acknowledge receipt as soon as possible.
+- We will keep you informed of investigation and remediation progress.
+- Please allow a reasonable window to fix and release a patch before public disclosure.
+
+Thank you for helping keep PrivateGPT and its users safe.


### PR DESCRIPTION
# Description

Researchers currently have no documented private security contact. This adds a root `SECURITY.md` with private disclosure channels so vulnerabilities are not filed as public issues.

Fixes #2304
Related: #1595

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] Added new unit/integration tests
- [x] I stared at the code and made sure it makes sense

**Test Configuration**:
* Docs-only change (SECURITY.md)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran `make check; make test` to ensure mypy and tests pass
